### PR TITLE
Task role support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,10 @@ For detailed information about the available actions, arguments and options, run
 
 Examples
 --------
-All examples assume, that authentication has already been configured.  
+All examples assume, that authentication has already been configured.
+
+Deployment
+----------
 
 Simple Redeploy
 ===============
@@ -134,12 +137,27 @@ To change the command of a specific container, run the following command::
 
 This will modify the **webserver** container and change its command to "nginx".
 
+
+Set a task role
+===============
+To change or set the role, the service's task should run as, use the following command::
+
+    $ ecs deploy my-cluster my-service -r arn:aws:iam::123456789012:role/MySpecialEcsTaskRole
+
+This will set the task role to "MySpecialEcsTaskRole".
+
+Scaling
+-------
+
 Scale a service
 ===============
 To change the number of running tasks and scale a service up and down, run this command::
 
     $ ecs scale my-cluster my-service 4
 
+
+Running a Task
+--------------
 
 Run a one-off task
 ==================

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -27,6 +27,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
 @click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--region', required=False, help='AWS region')
 @click.option('--access-key-id', required=False, help='AWS access key id')
 @click.option('--secret-access-key', required=False, help='AWS secret access yey')
@@ -36,7 +37,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment')
 @click.option('--comment', required=False, help='Description/comment for recording the deployment')
 @click.option('--user', required=False, help='User who executes the deployment (used for recording)')
-def deploy(cluster, service, tag, image, command, env, access_key_id, secret_access_key, region, profile, timeout,
+def deploy(cluster, service, tag, image, command, env, role, access_key_id, secret_access_key, region, profile, timeout,
            newrelic_apikey, newrelic_appid, comment, user):
     """
     Redeploy or modify a service.
@@ -57,6 +58,7 @@ def deploy(cluster, service, tag, image, command, env, access_key_id, secret_acc
         task_definition.set_images(tag, **{key: value for (key, value) in image})
         task_definition.set_commands(**{key: value for (key, value) in command})
         task_definition.set_environment(env)
+        task_definition.set_role_arn(role)
         print_diff(task_definition)
 
         click.secho('Creating new task definition revision')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Simplify AWS ECS deployments
 """
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'botocore', 'boto3', 'future', 'requests']
+dependencies = ['click', 'botocore', 'boto3>=1.4.0', 'future', 'requests']
 
 setup(
     name='ecs-deploy',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,20 @@ def test_deploy(get_client, runner):
 
 
 @patch('ecs_deploy.cli.get_client')
+def test_deploy_with_role_arn(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '-r', 'arn:new:role'))
+    assert result.exit_code == 0
+    assert not result.exception
+    assert u'Successfully created revision: 2' in result.output
+    assert u'Successfully deregistered revision: 1' in result.output
+    assert u'Successfully changed task definition to: test-task:2' in result.output
+    assert u'Deployment successful' in result.output
+    assert u"Updating task definition" in result.output
+    assert u"Changed role_arn to: \"arn:new:role\" (was: \"arn:test:role:1\")" in result.output
+
+
+@patch('ecs_deploy.cli.get_client')
 def test_deploy_new_tag(get_client, runner):
     get_client.return_value = EcsTestClient('acces_key', 'secret_key')
     result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '-t', 'latest'))


### PR DESCRIPTION
This PR adds support for ECS' new task role capabilities and boto's `--task-role-arn` option.
It introduces a new CLI parameter `-r` or `--role` to set a task role ARN on demand.