### PR TITLE
Add parameter --task to deploy based on a specific task definition

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -17,7 +17,10 @@ class EcsClient(object):
         return self.boto.describe_services(cluster=cluster_name, services=[service_name])
 
     def describe_task_definition(self, task_definition_arn):
-        return self.boto.describe_task_definition(taskDefinition=task_definition_arn)
+        try:
+            return self.boto.describe_task_definition(taskDefinition=task_definition_arn)
+        except ClientError:
+            raise UnknownTaskDefinitionError('Unknown task definition arn: %s' % task_definition_arn)
 
     def list_tasks(self, cluster_name, service_name):
         return self.boto.list_tasks(cluster=cluster_name, serviceName=service_name)
@@ -373,4 +376,8 @@ class ConnectionError(EcsError):
 
 
 class UnknownContainerError(EcsError):
+    pass
+
+
+class UnknownTaskDefinitionError(EcsError):
     pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,8 @@ from ecs_deploy import cli
 from ecs_deploy.cli import get_client, record_deployment
 from ecs_deploy.ecs import EcsClient
 from ecs_deploy.newrelic import Deployment, NewRelicDeploymentException
-from tests.test_ecs import EcsTestClient, CLUSTER_NAME, SERVICE_NAME
+from tests.test_ecs import EcsTestClient, CLUSTER_NAME, SERVICE_NAME, \
+    TASK_DEFINITION_ARN_1
 
 
 @pytest.fixture
@@ -189,6 +190,27 @@ def test_deploy_with_newrelic_errors(get_client, deploy, runner):
 
 
 @patch('ecs_deploy.cli.get_client')
+def test_deploy_task_definition_arn(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '--task', TASK_DEFINITION_ARN_1))
+    assert result.exit_code == 0
+    assert not result.exception
+    assert u"Deploying based on task definition: %s" % TASK_DEFINITION_ARN_1 in result.output
+    assert u'Successfully created revision: 2' in result.output
+    assert u'Successfully deregistered revision: 1' in result.output
+    assert u'Successfully changed task definition to: test-task:2' in result.output
+    assert u'Deployment successful' in result.output
+
+
+@patch('ecs_deploy.cli.get_client')
+def test_deploy_unknown_task_definition_arn(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '--task', u'arn:aws:ecs:eu-central-1:123456789012:task-definition/foobar:55'))
+    assert result.exit_code == 1
+    assert u"Unknown task definition arn: arn:aws:ecs:eu-central-1:123456789012:task-definition/foobar:55" in result.output
+
+
+@patch('ecs_deploy.cli.get_client')
 def test_scale_without_credentials(get_client, runner):
     get_client.return_value = EcsTestClient()
     result = runner.invoke(cli.scale, (CLUSTER_NAME, SERVICE_NAME, '2'))
@@ -241,21 +263,6 @@ def test_scale_with_timeout(get_client, runner):
 
 
 @patch('ecs_deploy.cli.get_client')
-def test_scale_without_credentials(get_client, runner):
-    get_client.return_value = EcsTestClient()
-    result = runner.invoke(cli.scale, (CLUSTER_NAME, SERVICE_NAME, '2'))
-    assert result.exit_code == 1
-    assert result.output == u'Unable to locate credentials. Configure credentials by running "aws configure".\n\n'
-
-
-@patch('ecs_deploy.cli.get_client')
-def test_scale_with_invalid_service(get_client, runner):
-    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
-    result = runner.invoke(cli.scale, (CLUSTER_NAME, 'unknown-service', '2'))
-    assert result.exit_code == 1
-    assert result.output == u'An error occurred when calling the DescribeServices operation: Service not found.\n\n'
-
-@patch('ecs_deploy.cli.get_client')
 def test_run_task(get_client, runner):
     get_client.return_value = EcsTestClient('acces_key', 'secret_key')
     result = runner.invoke(cli.run, (CLUSTER_NAME, 'test-task'))
@@ -263,7 +270,7 @@ def test_run_task(get_client, runner):
     assert not result.exception
     assert result.exit_code == 0
 
-    assert u"Successfully started 2 instances of task: test-task:1" in result.output
+    assert u"Successfully started 2 instances of task: test-task:2" in result.output
     assert u"- arn:foo:bar" in result.output
     assert u"- arn:lorem:ipsum" in result.output
 
@@ -278,7 +285,7 @@ def test_run_task_with_command(get_client, runner):
 
     assert u"Using task definition: test-task" in result.output
     assert u"Changed command of container 'webserver' to: \"date\" (was: \"run\")" in result.output
-    assert u"Successfully started 2 instances of task: test-task:1" in result.output
+    assert u"Successfully started 2 instances of task: test-task:2" in result.output
     assert u"- arn:foo:bar" in result.output
     assert u"- arn:lorem:ipsum" in result.output
 
@@ -293,7 +300,7 @@ def test_run_task_with_environment_var(get_client, runner):
 
     assert u"Using task definition: test-task" in result.output
     assert u'Changed environment of container \'application\' to: {"foo": "bar"} (was: {})' in result.output
-    assert u"Successfully started 2 instances of task: test-task:1" in result.output
+    assert u"Successfully started 2 instances of task: test-task:2" in result.output
     assert u"- arn:foo:bar" in result.output
     assert u"- arn:lorem:ipsum" in result.output
 


### PR DESCRIPTION
The `task` parameter can be:
- a full task ARN or
- a task family name with a specific revision (e.g. `my-task:123`) or
- just a task family name (e.g. `my-task`). In that case, the most recent revision is used

Fixes #17 