### PR TITLE
Fix override command

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -187,7 +187,7 @@ class EcsTaskDefinition(dict):
                 override = dict(name=diff.container)
                 overrides.append(override)
             if diff.field == 'command':
-                override['command'] = diff.value
+                override['command'] = [diff.value]
             elif diff.field == 'environment':
                 override['environment'] = self.get_overrides_env(diff.value)
         return overrides

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -187,14 +187,10 @@ class EcsTaskDefinition(dict):
                 override = dict(name=diff.container)
                 overrides.append(override)
             if diff.field == 'command':
-                override['command'] = self.get_overrides_command(diff.value)
+                override['command'] = diff.value
             elif diff.field == 'environment':
                 override['environment'] = self.get_overrides_env(diff.value)
         return overrides
-
-    @staticmethod
-    def get_overrides_command(command):
-        return command.split(' ')
 
     @staticmethod
     def get_overrides_env(env):

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -340,7 +340,7 @@ def test_task_get_overrides_with_command(task_definition):
     task_definition.set_commands(webserver='/usr/bin/python script.py')
     overrides = task_definition.get_overrides()
     assert len(overrides) == 1
-    assert overrides[0]['command'] == ['/usr/bin/python','script.py']
+    assert overrides[0]['command'] == ['/usr/bin/python script.py']
 
 
 def test_task_get_overrides_with_environment(task_definition):
@@ -357,7 +357,7 @@ def test_task_get_overrides_with_commandand_environment(task_definition):
     overrides = task_definition.get_overrides()
     assert len(overrides) == 1
     assert overrides[0]['name'] == 'webserver'
-    assert overrides[0]['command'] == ['/usr/bin/python','script.py']
+    assert overrides[0]['command'] == ['/usr/bin/python script.py']
     assert dict(name='foo', value='baz') in overrides[0]['environment']
 
 
@@ -367,15 +367,9 @@ def test_task_get_overrides_with_commandand_environment_for_multiple_containers(
     overrides = task_definition.get_overrides()
     assert len(overrides) == 2
     assert overrides[0]['name'] == 'application'
-    assert overrides[0]['command'] == ['/usr/bin/python','script.py']
+    assert overrides[0]['command'] == ['/usr/bin/python script.py']
     assert overrides[1]['name'] == 'webserver'
     assert dict(name='foo', value='baz') in overrides[1]['environment']
-
-
-def test_task_get_overrides_command(task_definition):
-    command = task_definition.get_overrides_command('/usr/bin/python script.py')
-    assert isinstance(command, list)
-    assert command == ['/usr/bin/python','script.py']
 
 
 def test_task_get_overrides_environment(task_definition):


### PR DESCRIPTION
I tried below command.

```bash
ecs run cluster_name task_definition_name -c container_name "bundle exec rake db:migrate"
```

I expected run a DB migration.
But, it executed bundle command.
I investigate this issue.

Originally ecs run command registered override command is ["bundle","exec","rake","db:migrate"]
I try register command ["bundle exec rake db:migrate"], is correctly works.
And fix it.

Thanks 😄 