### PR TITLE
Only print changed environment variables

### DIFF
--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -62,9 +62,11 @@ def get_client(access_key_id, secret_access_key, region, profile):
               help='Description/comment for recording the deployment')
 @click.option('--user', required=False,
               help='User who executes the deployment (used for recording)')
+@click.option('--diff/--no-diff', default=True,
+              help='Print what values were changed in the task definition')
 def deploy(cluster, service, tag, image, command, env, role, task, region,
            access_key_id, secret_access_key, profile, timeout, newrelic_apikey,
-           newrelic_appid, comment, user, ignore_warnings):
+           newrelic_appid, comment, user, ignore_warnings, diff):
     """
     Redeploy or modify a service.
 
@@ -91,7 +93,9 @@ def deploy(cluster, service, tag, image, command, env, role, task, region,
         td.set_commands(**{key: value for (key, value) in command})
         td.set_environment(env)
         td.set_role_arn(role)
-        print_diff(td)
+
+        if diff:
+            print_diff(td)
 
         click.secho('Creating new task definition revision')
         new_td = deployment.update_task_definition(td)
@@ -194,8 +198,10 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key,
               help='AWS secret access key')
 @click.option('--profile',
               help='AWS configuration profile name')
+@click.option('--diff/--no-diff', default=True,
+              help='Print what values were changed in the task definition')
 def run(cluster, task, count, command, env, region, access_key_id,
-        secret_access_key, profile):
+        secret_access_key, profile, diff):
     """
     Run a one-off task.
 
@@ -211,7 +217,9 @@ def run(cluster, task, count, command, env, region, access_key_id,
         td = action.get_task_definition(task)
         td.set_commands(**{key: value for (key, value) in command})
         td.set_environment(env)
-        print_diff(td, 'Using task definition: %s' % task)
+
+        if diff:
+            print_diff(td, 'Using task definition: %s' % task)
 
         action.run(td, count, 'ECS Deploy')
 

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from json import dumps
 
 from boto3.session import Session
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -299,19 +298,36 @@ class EcsTaskDefinitionDiff(object):
         self.old_value = old_value
 
     def __repr__(self):
-        if self.container:
-            return u"Changed %s of container '%s' to: %s (was: %s)" % (
+        if self.field == u'environment':
+            return '\n'.join(self._get_environment_diffs(
+                self.container,
+                self.value,
+                self.old_value,
+            ))
+        elif self.container:
+            return u'Changed %s of container "%s" to: "%s" (was: "%s")' % (
                 self.field,
                 self.container,
-                dumps(self.value),
-                dumps(self.old_value)
+                self.value,
+                self.old_value
             )
         else:
-            return u"Changed %s to: %s (was: %s)" % (
+            return u'Changed %s to: "%s" (was: "%s")' % (
                 self.field,
-                dumps(self.value),
-                dumps(self.old_value)
+                self.value,
+                self.old_value
             )
+
+    @staticmethod
+    def _get_environment_diffs(container, env, old_env):
+        msg = u'Changed environment "%s" of container "%s" to: "%s"'
+        diffs = []
+        for name, value in env.items():
+            old_value = old_env.get(name)
+            if value != old_value or not old_value:
+                message = msg % (name, container, value)
+                diffs.append(message)
+        return diffs
 
 
 class EcsAction(object):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,7 +81,7 @@ def test_deploy_with_role_arn(get_client, runner):
     assert u'Successfully changed task definition to: test-task:2' in result.output
     assert u'Deployment successful' in result.output
     assert u"Updating task definition" in result.output
-    assert u"Changed role_arn to: \"arn:new:role\" (was: \"arn:test:role:1\")" in result.output
+    assert u'Changed role_arn to: "arn:new:role" (was: "arn:test:role:1")' in result.output
 
 
 @patch('ecs_deploy.cli.get_client')
@@ -91,8 +91,8 @@ def test_deploy_new_tag(get_client, runner):
     assert result.exit_code == 0
     assert not result.exception
     assert u"Updating task definition" in result.output
-    assert u"Changed image of container 'webserver' to: \"webserver:latest\" (was: \"webserver:123\")" in result.output
-    assert u"Changed image of container 'application' to: \"application:latest\" (was: \"application:123\")" in result.output
+    assert u'Changed image of container "webserver" to: "webserver:latest" (was: "webserver:123")' in result.output
+    assert u'Changed image of container "application" to: "application:latest" (was: "application:123")' in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
@@ -106,7 +106,7 @@ def test_deploy_one_new_image(get_client, runner):
     assert result.exit_code == 0
     assert not result.exception
     assert u"Updating task definition" in result.output
-    assert u"Changed image of container 'application' to: \"application:latest\" (was: \"application:123\")" in result.output
+    assert u'Changed image of container "application" to: "application:latest" (was: "application:123")' in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
@@ -121,8 +121,8 @@ def test_deploy_two_new_images(get_client, runner):
     assert result.exit_code == 0
     assert not result.exception
     assert u"Updating task definition" in result.output
-    assert u"Changed image of container 'webserver' to: \"webserver:latest\" (was: \"webserver:123\")" in result.output
-    assert u"Changed image of container 'application' to: \"application:latest\" (was: \"application:123\")" in result.output
+    assert u'Changed image of container "webserver" to: "webserver:latest" (was: "webserver:123")' in result.output
+    assert u'Changed image of container "application" to: "application:latest" (was: "application:123")' in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
@@ -136,7 +136,7 @@ def test_deploy_one_new_command(get_client, runner):
     assert result.exit_code == 0
     assert not result.exception
     assert u"Updating task definition" in result.output
-    assert u"Changed command of container 'application' to: \"foobar\" (was: \"run\")" in result.output
+    assert u'Changed command of container "application" to: "foobar" (was: "run")' in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
@@ -154,10 +154,25 @@ def test_deploy_one_new_environment_variable(get_client, runner):
     assert not result.exception
 
     assert u"Updating task definition" in result.output
-    assert u'Changed environment of container \'application\' to: {"foo": "bar"} (was: {})' in result.output
-    assert u'Changed environment of container \'webserver\' to: ' in result.output
-    assert u'"foo": "baz"' in result.output
-    assert u'"lorem": "ipsum"' in result.output
+    assert u'Changed environment "foo" of container "application" to: "bar"' in result.output
+    assert u'Changed environment "foo" of container "webserver" to: "baz"' in result.output
+    assert u'Changed environment "lorem" of container "webserver" to: "ipsum"' not in result.output
+    assert u'Successfully created revision: 2' in result.output
+    assert u'Successfully deregistered revision: 1' in result.output
+    assert u'Successfully changed task definition to: test-task:2' in result.output
+    assert u'Deployment successful' in result.output
+
+
+@patch('ecs_deploy.cli.get_client')
+def test_deploy_without_changing_environment_variable(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '-e', 'webserver', 'foo', 'bar'))
+
+    assert result.exit_code == 0
+    assert not result.exception
+
+    assert u"Updating task definition" in result.output
+    assert u'Changed environment' not in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
@@ -320,7 +335,7 @@ def test_run_task_with_command(get_client, runner):
     assert result.exit_code == 0
 
     assert u"Using task definition: test-task" in result.output
-    assert u"Changed command of container 'webserver' to: \"date\" (was: \"run\")" in result.output
+    assert u'Changed command of container "webserver" to: "date" (was: "run")' in result.output
     assert u"Successfully started 2 instances of task: test-task:2" in result.output
     assert u"- arn:foo:bar" in result.output
     assert u"- arn:lorem:ipsum" in result.output
@@ -335,7 +350,7 @@ def test_run_task_with_environment_var(get_client, runner):
     assert result.exit_code == 0
 
     assert u"Using task definition: test-task" in result.output
-    assert u'Changed environment of container \'application\' to: {"foo": "bar"} (was: {})' in result.output
+    assert u'Changed environment "foo" of container "application" to: "bar"' in result.output
     assert u"Successfully started 2 instances of task: test-task:2" in result.output
     assert u"- arn:foo:bar" in result.output
     assert u"- arn:lorem:ipsum" in result.output

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -387,7 +387,7 @@ def test_task_get_overrides_environment(task_definition):
 
 def test_task_definition_diff():
     diff = EcsTaskDefinitionDiff(u'webserver', u'image', u'new', u'old')
-    assert str(diff) == u"Changed image of container 'webserver' to: \"new\" (was: \"old\")"
+    assert str(diff) == u'Changed image of container "webserver" to: "new" (was: "old")'
 
 
 @patch.object(Session, 'client')


### PR DESCRIPTION
* only print changed environment variables
* print one line output per changed environment variable
* new flags: `--diff` (default) and `--no-diff` to show/hide the differences of the old and new task definition

Fixes #26 