### PR TITLE
Support unknown task definition properties

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -142,33 +142,21 @@ class EcsTaskDefinition(object):
     def __init__(self, containerDefinitions, volumes, family, revision,
                  taskRoleArn, status, taskDefinitionArn, requiresAttributes,
                  **kwargs):
-        self.containerDefinitions = containerDefinitions
+        self.containers = containerDefinitions
         self.volumes = volumes
         self.family = family
         self.revision = revision
-        self.taskRoleArn = taskRoleArn
-        self.taskDefinitionArn = taskDefinitionArn
+        self.role_arn = taskRoleArn
+        self.arn = taskDefinitionArn
         self.status = status
-        self.requiresAttributes = requiresAttributes
+        self.requires_attributes = requiresAttributes
         self.additional_properties = kwargs
         self._diff = []
 
     @property
-    def containers(self):
-        return self.containerDefinitions
-
-    @property
     def container_names(self):
-        for container in self.containerDefinitions:
+        for container in self.containers:
             yield container[u'name']
-
-    @property
-    def arn(self):
-        return self.taskDefinitionArn
-
-    @property
-    def role_arn(self):
-        return self.taskRoleArn
 
     @property
     def family_revision(self):
@@ -284,9 +272,9 @@ class EcsTaskDefinition(object):
                 container=None,
                 field=u'role_arn',
                 value=role_arn,
-                old_value=self.taskRoleArn
+                old_value=self.role_arn
             )
-            self.taskRoleArn = role_arn
+            self.role_arn = role_arn
             self._diff.append(diff)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Simplify AWS ECS deployments
 """
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'botocore', 'boto3>=1.4.0', 'future', 'requests']
+dependencies = ['click', 'botocore', 'boto3>=1.4.7', 'future', 'requests']
 
 setup(
     name='ecs-deploy',

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -49,6 +49,8 @@ PAYLOAD_TASK_DEFINITION_1 = {
     u'containerDefinitions': deepcopy(TASK_DEFINITION_CONTAINERS_1),
     u'status': u'active',
     u'requiresAttributes': {},
+    u'networkMode': u'host',
+    u'placementConstraints': {},
     u'unknownProperty': u'lorem-ipsum',
 }
 
@@ -61,7 +63,7 @@ PAYLOAD_TASK_DEFINITION_2 = {
     u'containerDefinitions': deepcopy(TASK_DEFINITION_CONTAINERS_2),
     u'status': u'active',
     u'requiresAttributes': {},
-    u'undefinedProperty': u'lorem-ipsum',
+    u'unknownProperty': u'lorem-ipsum',
 }
 
 TASK_ARN_1 = u'arn:aws:ecs:eu-central-1:123456789012:task/12345678-1234-1234-1234-123456789011'
@@ -579,7 +581,11 @@ def test_update_task_definition(client, task_definition):
         containers=task_definition.containers,
         volumes=task_definition.volumes,
         role_arn=task_definition.role_arn,
-        additional_properties={u'unknownProperty': u'lorem-ipsum'}
+        additional_properties={
+            u'networkMode': u'host',
+            u'placementConstraints': {},
+            u'unknownProperty': u'lorem-ipsum'
+        }
     )
     client.deregister_task_definition.assert_called_once_with(
         task_definition.arn


### PR DESCRIPTION
Support new task definition properties like `networkMode` or `placementConstraints`. 
Even though they can not be manipulated with `ecs-deploy` yet, at least these properties retain in the new task definition.

Fixes #25 