### PR TITLE
Make requiresAttributes an optional ECS task definition property

### DIFF
--- a/ecs_deploy/__init__.py
+++ b/ecs_deploy/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.4.1'
+VERSION = '1.4.2'

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -140,7 +140,7 @@ class EcsService(dict):
 
 class EcsTaskDefinition(object):
     def __init__(self, containerDefinitions, volumes, family, revision,
-                 status, taskDefinitionArn, requiresAttributes,
+                 status, taskDefinitionArn, requiresAttributes=None,
                  taskRoleArn=None, **kwargs):
         self.containers = containerDefinitions
         self.volumes = volumes
@@ -148,7 +148,7 @@ class EcsTaskDefinition(object):
         self.revision = revision
         self.status = status
         self.arn = taskDefinitionArn
-        self.requires_attributes = requiresAttributes
+        self.requires_attributes = requiresAttributes or {}
         self.role_arn = taskRoleArn or u''
         self.additional_properties = kwargs
         self._diff = []

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -61,7 +61,6 @@ PAYLOAD_TASK_DEFINITION_2 = {
     u'volumes': deepcopy(TASK_DEFINITION_VOLUMES_2),
     u'containerDefinitions': deepcopy(TASK_DEFINITION_CONTAINERS_2),
     u'status': u'active',
-    u'requiresAttributes': {},
     u'unknownProperty': u'lorem-ipsum',
 }
 


### PR DESCRIPTION
The task definition property `requiresAttributes` is not always included in the ECS task definition response. This is currently not used in `ecs-deploy`, so it may be optional.

fixes #35 