### PR TITLE
Support for aws_session_token in EcsClient constructor

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -7,9 +7,10 @@ from dateutil.tz.tz import tzlocal
 
 class EcsClient(object):
     def __init__(self, access_key_id=None, secret_access_key=None,
-                 region=None, profile=None):
+                 session_token=None, region=None, profile=None):
         session = Session(aws_access_key_id=access_key_id,
                           aws_secret_access_key=secret_access_key,
+                          aws_session_token=session_token,
                           region_name=region,
                           profile_name=profile)
         self.boto = session.client(u'ecs')

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -7,7 +7,7 @@ from dateutil.tz.tz import tzlocal
 
 class EcsClient(object):
     def __init__(self, access_key_id=None, secret_access_key=None,
-                 session_token=None, region=None, profile=None):
+                 region=None, profile=None, session_token=None):
         session = Session(aws_access_key_id=access_key_id,
                           aws_secret_access_key=secret_access_key,
                           aws_session_token=session_token,

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -397,10 +397,11 @@ def test_task_definition_diff():
 def test_client_init(mocked_init, mocked_client):
     mocked_init.return_value = None
 
-    EcsClient(u'access_key_id', u'secret_access_key', u'region', u'profile')
+    EcsClient(u'access_key_id', u'secret_access_key', u'session_token', u'region', u'profile')
 
     mocked_init.assert_called_once_with(aws_access_key_id=u'access_key_id',
                                         aws_secret_access_key=u'secret_access_key',
+                                        aws_session_token=u'session_token',
                                         profile_name=u'profile',
                                         region_name=u'region')
     mocked_client.assert_called_once_with(u'ecs')
@@ -411,7 +412,7 @@ def test_client_init(mocked_init, mocked_client):
 @patch.object(Session, '__init__')
 def client(mocked_init, mocked_client):
     mocked_init.return_value = None
-    return EcsClient(u'access_key_id', u'secret_access_key', u'region', u'profile')
+    return EcsClient(u'access_key_id', u'secret_access_key', u'session_token', u'region', u'profile')
 
 
 def test_client_describe_services(client):

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -397,13 +397,13 @@ def test_task_definition_diff():
 def test_client_init(mocked_init, mocked_client):
     mocked_init.return_value = None
 
-    EcsClient(u'access_key_id', u'secret_access_key', u'session_token', u'region', u'profile')
+    EcsClient(u'access_key_id', u'secret_access_key', u'region', u'profile', u'session_token')
 
     mocked_init.assert_called_once_with(aws_access_key_id=u'access_key_id',
                                         aws_secret_access_key=u'secret_access_key',
-                                        aws_session_token=u'session_token',
                                         profile_name=u'profile',
-                                        region_name=u'region')
+                                        region_name=u'region',
+                                        aws_session_token=u'session_token')
     mocked_client.assert_called_once_with(u'ecs')
 
 
@@ -412,7 +412,7 @@ def test_client_init(mocked_init, mocked_client):
 @patch.object(Session, '__init__')
 def client(mocked_init, mocked_client):
     mocked_init.return_value = None
-    return EcsClient(u'access_key_id', u'secret_access_key', u'session_token', u'region', u'profile')
+    return EcsClient(u'access_key_id', u'secret_access_key', u'region', u'profile', u'session_token')
 
 
 def test_client_describe_services(client):


### PR DESCRIPTION
We're hoping to use ecs-deploy as part of a utility that switches role, determines the service ARN using boto3 and then uses ecs-deploy to update the task definition.
To do this we would be programmatically assuming a role (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html) and need to supply the aws_session_token.
