### PR TITLE
Add support for `secrets` in TaskDefinition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,9 @@ The **app**'s environment variable `APP_VARIABLE` will be set to "APP_VALUE".
 
 Set an secret from AWS Parameter Store
 ======================================
+
+**NOTE:** This option was introduced by AWS in ECS Agent v1.22.0. Make sure your ECS agent version is >= 1.22.0 or else your task will not deploy.
+
 To add a new or adjust an existing secret of a specific container, run the following command::
 
     $ ecs deploy my-cluster my-service -s webserver SOME_SECRET KEY_OF_SECRET_IN_PARAMETER_STORE

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ ECS Deploy
 Key Features
 ------------
 - support for complex task definitions (e.g. multiple containers & task role)
-- easily redeploy the current task definition (including `docker pull` of eventually updated images) 
+- easily redeploy the current task definition (including `docker pull` of eventually updated images)
 - deploy new versions/tags or all containers or just a single container in your task definition
 - scale up or down by adjusting the desired count of running tasks
 - add or adjust containers environment variables
@@ -25,11 +25,11 @@ Key Features
 TL;DR
 -----
 Deploy a new version of your service::
- 
+
     $ ecs deploy my-cluster my-service --tag 1.2.3
 
 Redeploy the current version of a service::
- 
+
     $ ecs deploy my-cluster my-service
 
 Scale up or down a service::
@@ -47,14 +47,14 @@ The project is availably on PyPI. Simply run::
 
 Configuration
 -------------
-As **ecs-deploy** is based on boto3 (the official AWS Python library), there are several ways to configure and store the 
-authentication credentials. Please read the boto3 documentation for more details 
+As **ecs-deploy** is based on boto3 (the official AWS Python library), there are several ways to configure and store the
+authentication credentials. Please read the boto3 documentation for more details
 (http://boto3.readthedocs.org/en/latest/guide/configuration.html#configuration). The simplest way is by running::
 
     $ aws configure
 
 Alternatively you can pass the AWS credentials (via `--access-key-id` and `--secret-access-key`) or the AWS
-configuration profile (via `--profile`) as options when you run `ecs`. 
+configuration profile (via `--profile`) as options when you run `ecs`.
 
 Actions
 -------
@@ -95,7 +95,7 @@ To redeploy a service without any modifications, but pulling the most recent ima
 This will duplicate the current task definition and cause the service to redeploy all running tasks.::
 
     $ ecs deploy my-cluster my-service
-   
+
 
 Deploy a new tag
 ================
@@ -109,7 +109,7 @@ Deploy a new image
 To change the image of a specific container, run the following command::
 
     $ ecs deploy my-cluster my-service --image webserver nginx:1.11.8
-     
+
 This will modify the **webserver** container only and change its image to "nginx:1.11.8".
 
 
@@ -118,7 +118,7 @@ Deploy several new images
 The `-i` or `--image` option can also be passed several times::
 
     $ ecs deploy my-cluster my-service -i webserver nginx:1.9 -i application my-app:1.2.3
-     
+
 This will change the **webserver**'s container image to "nginx:1.9" and the **application**'s image to "my-app:1.2.3".
 
 Deploy a custom task definition
@@ -136,9 +136,9 @@ A task family name with revision::
 Or just a task family name. It this case, the most recent revision is used::
 
     $ ecs deploy my-cluster my-service --task my-task
-    
+
 .. important::
-   ``ecs`` will still create a new task definition, which then is used in the service. 
+   ``ecs`` will still create a new task definition, which then is used in the service.
    This is done, to retain consistent behaviour and to ensure the ECS agent e.g. pulls all images.
    But the newly created task definition will be based on the given task, not the currently used task.
 
@@ -148,7 +148,7 @@ Set an environment variable
 To add a new or adjust an existing environment variable of a specific container, run the following command::
 
     $ ecs deploy my-cluster my-service -e webserver SOME_VARIABLE SOME_VALUE
-     
+
 This will modify the **webserver** container definition and add or overwrite the environment variable `SOME_VARIABLE` with the value "SOME_VALUE". This way you can add new or adjust already existing environment variables.
 
 
@@ -162,6 +162,17 @@ This will modify the definition **of two containers**.
 The **webserver**'s environment variable `SOME_VARIABLE` will be set to "SOME_VALUE" and the variable `OTHER_VARIABLE` to "OTHER_VALUE".
 The **app**'s environment variable `APP_VARIABLE` will be set to "APP_VALUE".
 
+Set an secret from AWS Parameter Store
+======================================
+To add a new or adjust an existing secret of a specific container, run the following command::
+
+    $ ecs deploy my-cluster my-service -s webserver SOME_SECRET KEY_OF_SECRET_IN_PARAMETER_STORE
+
+You can also specify the full arn of the parameter::
+
+    $ ecs deploy my-cluster my-service -s webserver SOME_SECRET arn:aws:ssm:<aws region>:<aws account id>:parameter/KEY_OF_SECRET_IN_PARAMETER_STORE
+
+This will modify the **webserver** container definition and add or overwrite the secret `SOME_SECRET` with the value of the `KEY_OF_SECRET_IN_PARAMETER_STORE` in the AWS Parameter Store.
 
 Modify a command
 ================
@@ -186,8 +197,8 @@ If your cluster is undersized or the service's deployment options are not optima
 might be incapable to run blue-green-deployments. In this case, you might see errors like these:
 
     ERROR: (service my-service) was unable to place a task because no container instance met all of
-    its requirements. The closest matching (container-instance 123456-1234-1234-1234-1234567890) is 
-    already using a port required by your task. For more information, see the Troubleshooting 
+    its requirements. The closest matching (container-instance 123456-1234-1234-1234-1234567890) is
+    already using a port required by your task. For more information, see the Troubleshooting
     section of the Amazon ECS Developer Guide.
 
 There might also be warnings about insufficient memory or CPU.
@@ -196,7 +207,7 @@ To ignore these warnings, you can run the deployment with the flag ``--ignore-wa
 
     $ ecs deploy my-cluster my-service --ignore-warnings
 
-In that case, the warning is printed, but the script continues and waits for a successful 
+In that case, the warning is printed, but the script continues and waits for a successful
 deployment until it times out.
 
 Scaling
@@ -243,12 +254,12 @@ To record a deployment in New Relic, you can provide the the API Key (**Attentio
 Via cli options::
 
     $ ecs deploy my-cluster my-service --newrelic-apikey ABCDEFGHIJKLMN --newrelic-appid 1234567890
-  
+
 Or implicitly via environment variables ``NEW_RELIC_API_KEY`` and ``NEW_RELIC_APP_ID`` ::
 
     $ export NEW_RELIC_API_KEY=ABCDEFGHIJKLMN
     $ export NEW_RELIC_APP_ID=1234567890
-    $ ecs deploy my-cluster my-service 
+    $ ecs deploy my-cluster my-service
 
 Optionally you can provide an additional comment to the deployment via ``--comment "New feature X"`` and the name of the user who deployed with ``--user john.doe``
 
@@ -279,6 +290,6 @@ There are some other libraries/tools available on GitHub, which also handle the 
 
 Shell
   ecs-deploy - https://github.com/silinternational/ecs-deploy
-  
+
 Ruby
   broadside - https://github.com/lumoslabs/broadside

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -30,6 +30,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
 @click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret variable (Not available for Fargate): <container> <name> <value>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--task', type=str, help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
 @click.option('--region', required=False, help='AWS region (e.g. eu-central-1)')
@@ -45,7 +46,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--diff/--no-diff', default=True, help='Print which values were changed in the task definition (default: --diff)')
 @click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
 @click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
-def deploy(cluster, service, tag, image, command, env, role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, comment, user, ignore_warnings, diff, deregister, rollback):
+def deploy(cluster, service, tag, image, command, env, secret, role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, comment, user, ignore_warnings, diff, deregister, rollback):
     """
     Redeploy or modify a service.
 
@@ -66,6 +67,7 @@ def deploy(cluster, service, tag, image, command, env, role, task, region, acces
         td.set_images(tag, **{key: value for (key, value) in image})
         td.set_commands(**{key: value for (key, value) in command})
         td.set_environment(env)
+        td.set_secrets(secret)
         td.set_role_arn(role)
 
         if diff:
@@ -149,12 +151,13 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.argument('count', required=False, default=1)
 @click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret variable (Not available for Fargate): <container> <name> <value>')
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-def run(cluster, task, count, command, env, region, access_key_id, secret_access_key, profile, diff):
+def run(cluster, task, count, command, env, secret, region, access_key_id, secret_access_key, profile, diff):
     """
     Run a one-off task.
 
@@ -170,6 +173,7 @@ def run(cluster, task, count, command, env, region, access_key_id, secret_access
         td = action.get_task_definition(task)
         td.set_commands(**{key: value for (key, value) in command})
         td.set_environment(env)
+        td.set_secrets(secret)
 
         if diff:
             print_diff(td, 'Using task definition: %s' % task)

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -30,7 +30,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
 @click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret variable (Not available for Fargate): <container> <name> <value>')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--task', type=str, help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
 @click.option('--region', required=False, help='AWS region (e.g. eu-central-1)')

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -379,7 +379,7 @@ class EcsTaskDefinitionDiff(object):
 
     @staticmethod
     def _get_secrets_diffs(container, secrets, old_secrets):
-        msg = u'Changed secrets "%s" of container "%s" to: "%s"'
+        msg = u'Changed secret "%s" of container "%s" to: "%s"'
         diffs = []
         for name, value in secrets.items():
             old_value = old_secrets.get(name)

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -186,6 +186,8 @@ class EcsTaskDefinition(object):
                 override['command'] = self.get_overrides_command(diff.value)
             elif diff.field == 'environment':
                 override['environment'] = self.get_overrides_env(diff.value)
+            elif diff.field == 'secrets':
+                override['secrets'] = self.get_overrides_secrets(diff.value)
         return overrides
 
     @staticmethod
@@ -195,6 +197,10 @@ class EcsTaskDefinition(object):
     @staticmethod
     def get_overrides_env(env):
         return [{"name": e, "value": env[e]} for e in env]
+
+    @staticmethod
+    def get_overrides_secrets(secrets):
+        return [{"name": s, "valueFrom": secrets[s]} for s in secrets]
 
     def set_images(self, tag=None, **images):
         self.validate_container_options(**images)
@@ -271,6 +277,42 @@ class EcsTaskDefinition(object):
             {"name": e, "value": merged[e]} for e in merged
         ]
 
+    def set_secrets(self, secrets_list):
+        secrets = {}
+
+        for secret in secrets_list:
+            secrets.setdefault(secret[0], {})
+            secrets[secret[0]][secret[1]] = secret[2]
+
+        self.validate_container_options(**secrets)
+        for container in self.containers:
+            if container[u'name'] in secrets:
+                self.apply_container_secrets(
+                    container=container,
+                    new_secrets=secrets[container[u'name']]
+                )
+
+    def apply_container_secrets(self, container, new_secrets):
+        secrets = container.get('secrets', {})
+        old_secrets = {secret['name']: secret['valueFrom'] for secret in secrets}
+        merged = old_secrets.copy()
+        merged.update(new_secrets)
+
+        if old_secrets == merged:
+            return
+
+        diff = EcsTaskDefinitionDiff(
+            container=container[u'name'],
+            field=u'secrets',
+            value=merged,
+            old_value=old_secrets
+        )
+        self._diff.append(diff)
+
+        container[u'secrets'] = [
+            {"name": s, "valueFrom": merged[s]} for s in merged
+        ]
+
     def validate_container_options(self, **container_options):
         for container_name in container_options:
             if container_name not in self.container_names:
@@ -304,6 +346,12 @@ class EcsTaskDefinitionDiff(object):
                 self.value,
                 self.old_value,
             ))
+        elif self.field == u'secrets':
+            return '\n'.join(self._get_secrets_diffs(
+                self.container,
+                self.value,
+                self.old_value,
+            ))
         elif self.container:
             return u'Changed %s of container "%s" to: "%s" (was: "%s")' % (
                 self.field,
@@ -324,6 +372,17 @@ class EcsTaskDefinitionDiff(object):
         diffs = []
         for name, value in env.items():
             old_value = old_env.get(name)
+            if value != old_value or not old_value:
+                message = msg % (name, container, value)
+                diffs.append(message)
+        return diffs
+
+    @staticmethod
+    def _get_secrets_diffs(container, secrets, old_secrets):
+        msg = u'Changed secrets "%s" of container "%s" to: "%s"'
+        diffs = []
+        for name, value in secrets.items():
+            old_value = old_secrets.get(name)
             if value != old_value or not old_value:
                 message = msg % (name, container, value)
                 diffs.append(message)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,7 +203,7 @@ def test_deploy_one_new_environment_variable(get_client, runner):
 
 
 @patch('ecs_deploy.cli.get_client')
-def test_deploy_one_new_secrets_variable(get_client, runner):
+def test_deploy_one_new_secret_variable(get_client, runner):
     get_client.return_value = EcsTestClient('acces_key', 'secret_key')
     result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME,
                                         '-s', 'application', 'baz', 'qux',
@@ -212,13 +212,11 @@ def test_deploy_one_new_secrets_variable(get_client, runner):
     assert result.exit_code == 0
     assert not result.exception
 
-    print(result.output)
-
     assert u"Deploying based on task definition: test-task:1" in result.output
     assert u"Updating task definition" in result.output
-    assert u'Changed secrets "baz" of container "application" to: "qux"' in result.output
-    assert u'Changed secrets "baz" of container "webserver" to: "quux"' in result.output
-    assert u'Changed secrets "dolor" of container "webserver" to: "sit"' not in result.output
+    assert u'Changed secret "baz" of container "application" to: "qux"' in result.output
+    assert u'Changed secret "baz" of container "webserver" to: "quux"' in result.output
+    assert u'Changed secret "dolor" of container "webserver" to: "sit"' not in result.output
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output


### PR DESCRIPTION
Adds a command line option `-s/--secret` to specify secrets for a task.

AWS recently added the ability to specify secrets in the AWS Parameter
Store which can be injected into the container as environment variables.

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html