### PR TITLE
[Docker] Creates a docker image from master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3-stretch
+
+RUN pip install --upgrade pip && \
+  pip install -e git+https://github.com/fabfuel/ecs-deploy.git@master#egg=ecs-deploy


### PR DESCRIPTION
The main purpose of this file is to provide an isolated environment which allow to use this tool over different platforms for non python developers.

For extra benefit just setup automatically deploy to Docker Hub https://docs.docker.com/docker-hub/builds/ 