### PR TITLE
command switch can now take more complicated arguments.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,7 +197,6 @@ To reset all existing secrets (secret environment variables) of a task definitio
 
 This will remove **all other** existing secret environment variables of **all containers** of the task definition, except for the new secret variable `NEW_SECRET` with the value coming from the AWS Parameter Store with the name "KEY_OF_SECRET_IN_PARAMETER_STORE" in the webserver container.
 
-
 Modify a command
 ================
 To change the command of a specific container, run the following command::
@@ -208,6 +207,15 @@ This will modify the **webserver** container and change its command to "nginx". 
 a command that requries arugments as well, then you can simply specify it like this as you would normally do:
 
     $ ecs deploy my-cluster my-service --command webserver "ngnix -c /etc/ngnix/ngnix.conf"
+
+This works fine as long as any of the arguments do not contain any spaces. In case arguments to the
+command itself contain spaces, then you can use the JSON format:
+
+$ ecs deploy my-cluster my-service --command webserver '["sh", "-c", "while true; do echo Time files like an arrow $(date); sleep 1; done;"]'
+
+More about this can be looked up in documentation.
+https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions
+
 
 
 
@@ -277,6 +285,8 @@ You can override the command definition via option ``-c`` or ``--command`` follo
 command in a natural syntax, e.g. no conversion to comma-separation required::
 
     $ ecs run my-cluster my-task -c my-container "python some-script.py param1 param2"
+
+The JSON sytax explained above regarding modifying a command is also applicable here.
 
 Monitoring
 ----------

--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ command in a natural syntax, e.g. no conversion to comma-separation required::
 
     $ ecs run my-cluster my-task -c my-container "python some-script.py param1 param2"
 
-The JSON sytax explained above regarding modifying a command is also applicable here.
+The JSON syntax explained above regarding modifying a command is also applicable here.
 
 Monitoring
 ----------

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -8,6 +8,12 @@ from dateutil.tz.tz import tzlocal
 
 JSON_LIST_REGEX = re.compile(r'^\[.*\]$')
 
+# Python2 raises ValueError
+try:
+    JSONDecodeError = json.JSONDecodeError
+except AttributeError:
+    JSONDecodeError = ValueError
+
 class EcsClient(object):
     def __init__(self, access_key_id=None, secret_access_key=None,
                  region=None, profile=None, session_token=None):
@@ -198,7 +204,7 @@ class EcsTaskDefinition(object):
         if re.match(JSON_LIST_REGEX, command):
             try:
                 return json.loads(command)
-            except json.JSONDecodeError as e:
+            except JSONDecodeError as e:
                 raise EcsTaskDefinitionCommandError("command should be valid JSON list."
                                                     "Got following command: {}"
                                                     "Resulting in error: {}".format(command, str(e)))

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -14,6 +14,7 @@ try:
 except AttributeError:
     JSONDecodeError = ValueError
 
+
 class EcsClient(object):
     def __init__(self, access_key_id=None, secret_access_key=None,
                  region=None, profile=None, session_token=None):
@@ -208,11 +209,13 @@ class EcsTaskDefinition(object):
             try:
                 return json.loads(command)
             except JSONDecodeError as e:
-                raise EcsTaskDefinitionCommandError("command should be valid JSON list."
-                                                    "Got following command: {}"
-                                                    "Resulting in error: {}".format(command, str(e)))
+                raise EcsTaskDefinitionCommandError(
+                    "command should be valid JSON list. Got following "
+                    "command: {} resulting in error: {}"
+                    .format(command, str(e)))
 
         return command.split(' ')
+
     @staticmethod
     def get_overrides_command(command):
         return EcsTaskDefinition.parse_command(command)
@@ -626,6 +629,7 @@ class TaskPlacementError(EcsError):
 
 class UnknownTaskDefinitionError(EcsError):
     pass
+
 
 class EcsTaskDefinitionCommandError(EcsError):
     pass

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -11,7 +11,7 @@ from mock.mock import patch
 from ecs_deploy.ecs import EcsService, EcsTaskDefinition, \
     UnknownContainerError, EcsTaskDefinitionDiff, EcsClient, \
     EcsAction, EcsConnectionError, DeployAction, ScaleAction, RunAction, \
-    UnknownTaskDefinitionError
+    EcsTaskDefinitionCommandError, UnknownTaskDefinitionError
 
 CLUSTER_NAME = u'test-cluster'
 CLUSTER_ARN = u'arn:aws:ecs:eu-central-1:123456789012:cluster/%s' % CLUSTER_NAME
@@ -373,6 +373,18 @@ def test_task_set_command_with_multiple_arguments(task_definition):
             assert container[u'command'] == [u'run-webserver', u'arg1', u'arg2']
         if container[u'name'] == u'application':
             assert container[u'command'] == [u'run-application', u'arg1', u'arg2']
+
+def test_task_set_command_as_json_list(task_definition):
+    task_definition.set_commands(webserver=u'["run-webserver", "arg1", "arg2"]', application=u'["run-application", "arg1", "arg2"]')
+    for container in task_definition.containers:
+        if container[u'name'] == u'webserver':
+            assert container[u'command'] == [u'run-webserver', u'arg1', u'arg2']
+        if container[u'name'] == u'application':
+            assert container[u'command'] == [u'run-application', u'arg1', u'arg2']
+
+def test_task_set_command_as_invalid_json_list(task_definition):
+    with pytest.raises(EcsTaskDefinitionCommandError):
+        task_definition.set_commands(webserver=u'["run-webserver, "arg1" arg2"]', application=u'["run-application" "arg1 "arg2"]')
 
 
 def test_task_set_command_for_unknown_container(task_definition):


### PR DESCRIPTION
The --command switch now can take more complicated arguments like this:

```
ecs deploy my-cluster my-service --command my-container '["sh", "-c", "while true; do echo Time files like an arrow $(date); sleep 1; done;"]'
```

`README` and tests are updated.

Please take a look @fabfuel 