### PR TITLE
Added support to set executionRoleArn on ecs deploy.

### DIFF
--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -32,6 +32,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
+@click.option('-x', '--execution-role', type=str, help='Sets the execution\'s role ARN: <execution role ARN>')
 @click.option('--task', type=str, help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
 @click.option('--region', required=False, help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', required=False, help='AWS access key id')
@@ -48,7 +49,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
 @click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
 @click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-def deploy(cluster, service, tag, image, command, env, secret, role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets):
+def deploy(cluster, service, tag, image, command, env, secret, role, execution_role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets):
     """
     Redeploy or modify a service.
 
@@ -71,6 +72,7 @@ def deploy(cluster, service, tag, image, command, env, secret, role, task, regio
         td.set_environment(env, exclusive_env)
         td.set_secrets(secret, exclusive_secrets)
         td.set_role_arn(role)
+        td.set_execution_role_arn(execution_role)
 
         if diff:
             print_diff(td)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,6 +119,20 @@ def test_deploy_with_role_arn(get_client, runner):
     assert u"Updating task definition" in result.output
     assert u'Changed role_arn to: "arn:new:role" (was: "arn:test:role:1")' in result.output
 
+@patch('ecs_deploy.cli.get_client')
+def test_deploy_with_execution_role_arn(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '-x', 'arn:new:role'))
+    assert result.exit_code == 0
+    assert not result.exception
+    assert u"Deploying based on task definition: test-task:1" in result.output
+    assert u'Successfully created revision: 2' in result.output
+    assert u'Successfully deregistered revision: 1' in result.output
+    assert u'Successfully changed task definition to: test-task:2' in result.output
+    assert u'Deployment successful' in result.output
+    assert u"Updating task definition" in result.output
+    assert u'Changed execution_role_arn to: "arn:new:role" (was: "arn:test:role:1")' in result.output
+
 
 @patch('ecs_deploy.cli.get_client')
 def test_deploy_new_tag(get_client, runner):

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -47,6 +47,7 @@ PAYLOAD_TASK_DEFINITION_1 = {
     u'family': TASK_DEFINITION_FAMILY_1,
     u'revision': TASK_DEFINITION_REVISION_1,
     u'taskRoleArn': TASK_DEFINITION_ROLE_ARN_1,
+    u'executionRoleArn': TASK_DEFINITION_ROLE_ARN_1,
     u'volumes': deepcopy(TASK_DEFINITION_VOLUMES_1),
     u'containerDefinitions': deepcopy(TASK_DEFINITION_CONTAINERS_1),
     u'status': u'active',
@@ -511,12 +512,14 @@ def test_client_register_task_definition(client):
     containers = [{u'name': u'foo'}]
     volumes = [{u'foo': u'bar'}]
     role_arn = 'arn:test:role'
+    execution_role_arn = 'arn:test:role'
     task_definition = EcsTaskDefinition(
         containerDefinitions=containers,
         volumes=volumes,
         family=u'family',
         revision=1,
         taskRoleArn=role_arn,
+        executionRoleArn=execution_role_arn,
         status='active',
         taskDefinitionArn='arn:task',
         requiresAttributes={},
@@ -528,6 +531,7 @@ def test_client_register_task_definition(client):
         containers=task_definition.containers,
         volumes=task_definition.volumes,
         role_arn=task_definition.role_arn,
+        execution_role_arn=execution_role_arn,
         additional_properties=task_definition.additional_properties
     )
 
@@ -536,6 +540,7 @@ def test_client_register_task_definition(client):
         containerDefinitions=containers,
         volumes=volumes,
         taskRoleArn=role_arn,
+        executionRoleArn=execution_role_arn,
         unkownProperty='foobar'
     )
 
@@ -650,6 +655,7 @@ def test_update_task_definition(client, task_definition):
         containers=task_definition.containers,
         volumes=task_definition.volumes,
         role_arn=task_definition.role_arn,
+        execution_role_arn=task_definition.execution_role_arn,
         additional_properties={
             u'networkMode': u'host',
             u'placementConstraints': {},
@@ -874,7 +880,8 @@ class EcsTestClient(object):
     def describe_tasks(self, cluster_name, task_arns):
         return deepcopy(RESPONSE_DESCRIBE_TASKS)
 
-    def register_task_definition(self, family, containers, volumes, role_arn, additional_properties):
+    def register_task_definition(self, family, containers, volumes, role_arn,
+                                 execution_role_arn, additional_properties):
         return deepcopy(RESPONSE_TASK_DEFINITION_2)
 
     def deregister_task_definition(self, task_definition_arn):


### PR DESCRIPTION
This pull request adds the `executionRoleArn` by using
* `-x`
* `--execution-role`

The cli option names need to be further discussed, I think.

This pull request resulted from issue #87 