### PR TITLE
allow extra EcsParameters to not be lost when updating rule

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -125,18 +125,9 @@ class EcsClient(object):
 
     def update_rule(self, cluster, rule, task_definition):
         target = self.events.list_targets_by_rule(Rule=rule)['Targets'][0]
-        self.events.put_targets(
-            Rule=rule,
-            Targets=[{
-                'Arn': task_definition.arn.partition('task-definition')[0] + 'cluster/' + cluster,
-                'Id': target['Id'],
-                'RoleArn': target['RoleArn'],
-                'EcsParameters': {
-                    'TaskDefinitionArn': task_definition.arn,
-                    'TaskCount': 1
-                }
-            }]
-        )
+        target['Arn'] = task_definition.arn.partition('task-definition')[0] + 'cluster/' + cluster
+        target['EcsParameters']['TaskDefinitionArn'] = task_definition.arn
+        self.events.put_targets(Rule=rule, Targets=[target])
         return target['Id']
 
 


### PR DESCRIPTION
When updating a cron job, it loses any network configuration data from the rule as it's overwriting the target. Updating it instead of replacing it ensures any new data is not lost.