### PR TITLE
Support platform version for FARGATE tasks.

### DIFF
--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -304,12 +304,13 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.option('--subnet', type=str, multiple=True, help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
 @click.option('--securitygroup', type=str, multiple=True, help='A security group ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
 @click.option('--public-ip', is_flag=True, default=False, help='Should a public IP address be assigned to the task (default: False)')
+@click.option('--platform-version', help='The version of the Fargate platform on which to run the task. Optional, FARGATE launch type only.', required=False)
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-def run(cluster, task, count, command, env, secret, launchtype, subnet, securitygroup, public_ip, region, access_key_id, secret_access_key, profile, diff):
+def run(cluster, task, count, command, env, secret, launchtype, subnet, securitygroup, public_ip, platform_version, region, access_key_id, secret_access_key, profile, diff):
     """
     Run a one-off task.
 
@@ -330,7 +331,7 @@ def run(cluster, task, count, command, env, secret, launchtype, subnet, security
         if diff:
             print_diff(td, 'Using task definition: %s' % task)
 
-        action.run(td, count, 'ECS Deploy', launchtype, subnet, securitygroup, public_ip)
+        action.run(td, count, 'ECS Deploy', launchtype, subnet, securitygroup, public_ip, platform_version)
 
         click.secho(
             'Successfully started %d instances of task: %s' % (

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -88,7 +88,7 @@ class EcsClient(object):
 
     def run_task(self, cluster, task_definition, count, started_by, overrides,
                  launchtype='EC2', subnets=(), security_groups=(),
-                 public_ip=False):
+                 public_ip=False, platform_version=None):
 
         if launchtype == LAUNCH_TYPE_FARGATE:
             if not subnets or not security_groups:
@@ -105,6 +105,9 @@ class EcsClient(object):
                 }
             }
 
+            if platform_version is None:
+                platform_version = 'LATEST'
+
             return self.boto.run_task(
                 cluster=cluster,
                 taskDefinition=task_definition,
@@ -112,7 +115,8 @@ class EcsClient(object):
                 startedBy=started_by,
                 overrides=overrides,
                 launchType=launchtype,
-                networkConfiguration=network_configuration
+                networkConfiguration=network_configuration,
+                platformVersion=platform_version,
             )
 
         return self.boto.run_task(
@@ -679,7 +683,7 @@ class RunAction(EcsAction):
         self.started_tasks = []
 
     def run(self, task_definition, count, started_by, launchtype, subnets,
-            security_groups, public_ip):
+            security_groups, public_ip, platform_version):
         try:
             result = self._client.run_task(
                 cluster=self._cluster_name,
@@ -690,7 +694,8 @@ class RunAction(EcsAction):
                 launchtype=launchtype,
                 subnets=subnets,
                 security_groups=security_groups,
-                public_ip=public_ip
+                public_ip=public_ip,
+                platform_version=platform_version,
             )
             self.started_tasks = result['tasks']
             return True

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -411,7 +411,7 @@ def test_task_set_command_with_multiple_arguments(task_definition):
             assert container[u'command'] == [u'run-application', u'arg1', u'arg2']
 
 def test_task_set_command_with_empty_argument(task_definition):
-    empty_argument = " " 
+    empty_argument = " "
     task_definition.set_commands(webserver=empty_argument + u'run-webserver arg1 arg2')
     for container in task_definition.containers:
         if container[u'name'] == u'webserver':
@@ -856,7 +856,7 @@ def test_run_action(client):
 def test_run_action_run(client, task_definition):
     action = RunAction(client, CLUSTER_NAME)
     client.run_task.return_value = dict(tasks=[dict(taskArn='A'), dict(taskArn='B')])
-    action.run(task_definition, 2, 'test', LAUNCH_TYPE_EC2, (), (), False)
+    action.run(task_definition, 2, 'test', LAUNCH_TYPE_EC2, (), (), False, None)
 
     client.run_task.assert_called_once_with(
         cluster=CLUSTER_NAME,
@@ -867,7 +867,8 @@ def test_run_action_run(client, task_definition):
         launchtype=LAUNCH_TYPE_EC2,
         subnets=(),
         security_groups=(),
-        public_ip=False
+        public_ip=False,
+        platform_version=None,
     )
 
     assert len(action.started_tasks) == 2
@@ -960,7 +961,7 @@ class EcsTestClient(object):
 
     def run_task(self, cluster, task_definition, count, started_by, overrides,
                  launchtype='EC2', subnets=(), security_groups=(),
-                 public_ip=False):
+                 public_ip=False, platform_version=None):
         if not self.access_key_id or not self.secret_access_key:
             raise EcsConnectionError(u'Unable to locate credentials. Configure credentials by running "aws configure".')
         if cluster == 'unknown-cluster':


### PR DESCRIPTION
When running a task with `ecs run`, support choosing between different versions of the Fargate platform.

This allows (as of the time of writing) use of 1.4.0, which is necessary to access EFS from fargate containers.

See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html for more information about platform versions. Confusingly `LATEST` _isn't_ the latest platform version, it is more akin to latest stable.