### PR TITLE
Register tags only if tags are existent (non-empty)

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -61,13 +61,15 @@ class EcsClient(object):
 
     def register_task_definition(self, family, containers, volumes, role_arn,
                                  execution_role_arn, tags, additional_properties):
+        if tags:
+            additional_properties['tags'] = tags
+
         return self.boto.register_task_definition(
             family=family,
             containerDefinitions=containers,
             volumes=volumes,
             taskRoleArn=role_arn,
             executionRoleArn=execution_role_arn,
-            tags=tags,
             **additional_properties
         )
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -605,6 +605,45 @@ def test_client_register_task_definition(client):
     )
 
 
+def test_client_register_task_definition_without_tags(client):
+    containers = [{u'name': u'foo'}]
+    volumes = [{u'foo': u'bar'}]
+    role_arn = 'arn:test:role'
+    execution_role_arn = 'arn:test:role'
+    task_definition = EcsTaskDefinition(
+        containerDefinitions=containers,
+        volumes=volumes,
+        family=u'family',
+        revision=1,
+        taskRoleArn=role_arn,
+        executionRoleArn=execution_role_arn,
+        tags={},
+        status='active',
+        taskDefinitionArn='arn:task',
+        requiresAttributes={},
+        unkownProperty='foobar'
+    )
+
+    client.register_task_definition(
+        family=task_definition.family,
+        containers=task_definition.containers,
+        volumes=task_definition.volumes,
+        role_arn=task_definition.role_arn,
+        execution_role_arn=execution_role_arn,
+        tags=task_definition.tags,
+        additional_properties=task_definition.additional_properties
+    )
+
+    client.boto.register_task_definition.assert_called_once_with(
+        family=u'family',
+        containerDefinitions=containers,
+        volumes=volumes,
+        taskRoleArn=role_arn,
+        executionRoleArn=execution_role_arn,
+        unkownProperty='foobar'
+    )
+
+
 def test_client_deregister_task_definition(client):
     client.deregister_task_definition(u'task_definition_arn')
     client.boto.deregister_task_definition.assert_called_once_with(taskDefinition=u'task_definition_arn')


### PR DESCRIPTION
Register tags (via **additional_properties) only if tags are existent, as boto client does not allow empty list of tags

This fixes #146, a bug which was introduced in release 1.10.3.
The buggy version already has been yanked from PyPI.

FYI @amilagm & @nitrocode