### PR TITLE
inspect stopped instances

### DIFF
--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -28,96 +28,53 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.argument('cluster')
 @click.argument('service')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-i', '--image', type=(str, str), multiple=True,
-              help='Overwrites the image for a container: <container> <image>')
-@click.option('-c', '--command', type=(str, str), multiple=True,
-              help='Overwrites the command in a container: <container> <command>')
-@click.option('-h', '--health-check', type=(str, str, int, int, int, int), multiple=True,
-              help='Overwrites the healthcheck in a container: <container> <command> <interval> <timeout> <retries> <start_period>')
-@click.option('--cpu', type=(str, int), multiple=True,
-              help='Overwrites the cpu value for a container: <container> <cpu>')
-@click.option('--memory', type=(str, int), multiple=True,
-              help='Overwrites the memory value for a container: <container> <memory>')
-@click.option('--memoryreservation', type=(str, int), multiple=True,
-              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('--privileged', type=(str, bool), multiple=True,
-              help='Overwrites the privileged value for a container: <container> <privileged>')
-@click.option('--essential', type=(str, bool), multiple=True,
-              help='Overwrites the essential value for a container: <container> <essential>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True,
-              help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
-              help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True,
-              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True,
-              help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
-@click.option('--system-control', type=(str, str, str), multiple=True,
-              help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
-@click.option('-p', '--port', type=(str, int, int), multiple=True,
-              help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-m', '--mount', type=(str, str, str), multiple=True,
-              help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-l', '--log', type=(str, str, str, str), multiple=True,
-              help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
+@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
+@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
+@click.option('-h', '--health-check', type=(str, str, int, int, int, int), multiple=True, help='Overwrites the healthcheck in a container: <container> <command> <interval> <timeout> <retries> <start_period>')
+@click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
+@click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
+@click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the privileged value for a container: <container> <privileged>')
+@click.option('--essential', type=(str, bool), multiple=True, help='Overwrites the essential value for a container: <container> <essential>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
+@click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
+@click.option('-p', '--port', type=(str, int, int), multiple=True, help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-m', '--mount', type=(str, str, str), multiple=True, help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-l', '--log', type=(str, str, str, str), multiple=True, help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('-x', '--execution-role', type=str, help='Sets the execution\'s role ARN: <execution role ARN>')
-@click.option('--task', type=str,
-              help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
+@click.option('--task', type=str, help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
 @click.option('--region', required=False, help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', required=False, help='AWS access key id')
 @click.option('--secret-access-key', required=False, help='AWS secret access key')
 @click.option('--profile', required=False, help='AWS configuration profile name')
-@click.option('--timeout', required=False, default=300, type=int,
-              help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
-@click.option('--ignore-warnings', is_flag=True,
-              help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
-@click.option('--newrelic-apikey', required=False,
-              help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
-@click.option('--newrelic-appid', required=False,
-              help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
-@click.option('--newrelic-region', required=False,
-              help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
-@click.option('--newrelic-revision', required=False,
-              help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
+@click.option('--timeout', required=False, default=300, type=int, help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
+@click.option('--ignore-warnings', is_flag=True, help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
+@click.option('--newrelic-apikey', required=False, help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
+@click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
+@click.option('--newrelic-region', required=False, help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
+@click.option('--newrelic-revision', required=False, help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
 @click.option('--comment', required=False, help='Description/comment for recording the deployment')
 @click.option('--user', required=False, help='User who executes the deployment (used for recording)')
-@click.option('--diff/--no-diff', default=True,
-              help='Print which values were changed in the task definition (default: --diff)')
-@click.option('--deregister/--no-deregister', default=True,
-              help='Deregister or keep the old task definition (default: --deregister)')
-@click.option('--rollback/--no-rollback', default=False,
-              help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
-@click.option('--exclusive-env', is_flag=True, default=False,
-              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False,
-              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--sleep-time', default=1, type=int,
-              help='Amount of seconds to wait between each check of the service (default: 1)')
-@click.option('--slack-url', required=False,
-              help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
-@click.option('--slack-service-match', default=".*", required=False,
-              help='A regular expression for defining, which services should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
-@click.option('--exclusive-ulimits', is_flag=True, default=False,
-              help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
-@click.option('--exclusive-system-controls', is_flag=True, default=False,
-              help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
-@click.option('--exclusive-ports', is_flag=True, default=False,
-              help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
-@click.option('--exclusive-mounts', is_flag=True, default=False,
-              help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
-@click.option('--volume', type=(str, str), multiple=True, required=False,
-              help='Set volume mapping from host to container in the task definition.')
-@click.option('--add-container', type=str, multiple=True, required=False,
-              help='Add a placeholder container in the task definition.')
-@click.option('--remove-container', type=str, multiple=True, required=False,
-              help='Remove a container from the task definition.')
-def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, privileged, essential,
-           env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, task, region,
-           access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region,
-           newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env,
-           exclusive_secrets, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports,
-           exclusive_mounts, volume, add_container, remove_container, slack_url, slack_service_match='.*'):
+@click.option('--diff/--no-diff', default=True, help='Print which values were changed in the task definition (default: --diff)')
+@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
+@click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
+@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--sleep-time', default=1, type=int, help='Amount of seconds to wait between each check of the service (default: 1)')
+@click.option('--slack-url', required=False, help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
+@click.option('--slack-service-match', default=".*", required=False, help='A regular expression for defining, which services should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
+@click.option('--exclusive-ulimits', is_flag=True, default=False, help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
+@click.option('--exclusive-system-controls', is_flag=True, default=False, help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
+@click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
+@click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
+@click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
+@click.option('--add-container', type=str, multiple=True, required=False, help='Add a placeholder container in the task definition.')
+@click.option('--remove-container', type=str, multiple=True, required=False, help='Remove a container from the task definition.')
+def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, privileged, essential, env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, slack_service_match='.*'):
     """
     Redeploy or modify a service.
 
@@ -135,8 +92,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
         deployment = DeployAction(client, cluster, service)
 
         td = get_task_definition(deployment, task)
-        # If there is a new container, add it at fd
-
+        # If there is a new container, add it at frist.
         td.add_containers(add_container)
         td.remove_containers(remove_container)
         td.set_images(tag, **{key: value for (key, value) in image})
@@ -207,79 +163,46 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.argument('cluster')
 @click.argument('task')
 @click.argument('rule')
-@click.option('-i', '--image', type=(str, str), multiple=True,
-              help='Overwrites the image for a container: <container> <image>')
+@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-c', '--command', type=(str, str), multiple=True,
-              help='Overwrites the command in a container: <container> <command>')
-@click.option('--cpu', type=(str, int), multiple=True,
-              help='Overwrites the cpu value for a container: <container> <cpu>')
-@click.option('--memory', type=(str, int), multiple=True,
-              help='Overwrites the memory value for a container: <container> <memory>')
-@click.option('--memoryreservation', type=(str, int), multiple=True,
-              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('--privileged', type=(str, bool), multiple=True,
-              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True,
-              help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True,
-              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True,
-              help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
-@click.option('--system-control', type=(str, str, str), multiple=True,
-              help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
-@click.option('-p', '--port', type=(str, int, int), multiple=True,
-              help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-m', '--mount', type=(str, str, str), multiple=True,
-              help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-l', '--log', type=(str, str, str, str), multiple=True,
-              help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
-              help='Load environment variables from .env-file')
+@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
+@click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
+@click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
+@click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
+@click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
+@click.option('-p', '--port', type=(str, int, int), multiple=True, help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-m', '--mount', type=(str, str, str), multiple=True, help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-l', '--log', type=(str, str, str, str), multiple=True, help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('-x', '--execution-role', type=str, help='Sets the execution\'s role ARN: <execution role ARN>')
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
-@click.option('--newrelic-apikey', required=False,
-              help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
-@click.option('--newrelic-appid', required=False,
-              help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
-@click.option('--newrelic-region', required=False,
-              help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
-@click.option('--newrelic-revision', required=False,
-              help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
+@click.option('--newrelic-apikey', required=False, help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
+@click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
+@click.option('--newrelic-region', required=False, help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
+@click.option('--newrelic-revision', required=False, help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
 @click.option('--comment', required=False, help='Description/comment for recording the deployment')
 @click.option('--user', required=False, help='User who executes the deployment (used for recording)')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-@click.option('--deregister/--no-deregister', default=True,
-              help='Deregister or keep the old task definition (default: --deregister)')
-@click.option('--rollback/--no-rollback', default=False,
-              help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
-@click.option('--exclusive-env', is_flag=True, default=False,
-              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False,
-              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--slack-url', required=False,
-              help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
-@click.option('--slack-service-match', default=".*", required=False,
-              help='A regular expression for defining, deployments of which crons should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
-@click.option('--exclusive-ulimits', is_flag=True, default=False,
-              help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
-@click.option('--exclusive-system-controls', is_flag=True, default=False,
-              help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
-@click.option('--exclusive-ports', is_flag=True, default=False,
-              help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
-@click.option('--exclusive-mounts', is_flag=True, default=False,
-              help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
-@click.option('--volume', type=(str, str), multiple=True, required=False,
-              help='Set volume mapping from host to container in the task definition.')
-def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, privileged, env, env_file, secret,
-         ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key,
-         newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister,
-         rollback, exclusive_env, exclusive_secrets, slack_url, slack_service_match, exclusive_ulimits,
-         exclusive_system_controls, exclusive_ports, exclusive_mounts, volume):
+@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
+@click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
+@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--slack-url', required=False, help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
+@click.option('--slack-service-match', default=".*", required=False, help='A regular expression for defining, deployments of which crons should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
+@click.option('--exclusive-ulimits', is_flag=True, default=False, help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
+@click.option('--exclusive-system-controls', is_flag=True, default=False, help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
+@click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
+@click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
+@click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
+def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, privileged, env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume):
     """
     Update a scheduled task.
 
@@ -345,31 +268,22 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
 
 @click.command()
 @click.argument('task')
-@click.option('-i', '--image', type=(str, str), multiple=True,
-              help='Overwrites the image for a container: <container> <image>')
+@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-c', '--command', type=(str, str), multiple=True,
-              help='Overwrites the command in a container: <container> <command>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True,
-              help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
-              help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True,
-              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-@click.option('--exclusive-env', is_flag=True, default=False,
-              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False,
-              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--deregister/--no-deregister', default=True,
-              help='Deregister or keep the old task definition (default: --deregister)')
-def update(task, image, tag, command, env, env_file, secret, role, region, access_key_id, secret_access_key, profile,
-           diff, exclusive_env, exclusive_secrets, deregister):
+@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
+def update(task, image, tag, command, env, env_file, secret, role, region, access_key_id, secret_access_key, profile, diff, exclusive_env, exclusive_secrets, deregister):
     """
     Update a task definition.
 
@@ -410,14 +324,10 @@ def update(task, image, tag, command, env, env_file, secret, role, region, acces
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
-@click.option('--timeout', default=300, type=int,
-              help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
-@click.option('--ignore-warnings', is_flag=True,
-              help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
-@click.option('--sleep-time', default=1, type=int,
-              help='Amount of seconds to wait between each check of the service (default: 1)')
-def scale(cluster, service, desired_count, access_key_id, secret_access_key, region, profile, timeout, ignore_warnings,
-          sleep_time):
+@click.option('--timeout', default=300, type=int, help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
+@click.option('--ignore-warnings', is_flag=True, help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
+@click.option('--sleep-time', default=1, type=int, help='Amount of seconds to wait between each check of the service (default: 1)')
+def scale(cluster, service, desired_count, access_key_id, secret_access_key, region, profile, timeout, ignore_warnings, sleep_time):
     """
     Scale a service up or down.
 
@@ -454,31 +364,20 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.argument('cluster')
 @click.argument('task')
 @click.argument('count', required=False, default=1)
-@click.option('-c', '--command', type=(str, str), multiple=True,
-              help='Overwrites the command in a container: <container> <command>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True,
-              help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
-              help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True,
-              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('--launchtype', type=click.Choice([LAUNCH_TYPE_EC2, LAUNCH_TYPE_FARGATE]), default=LAUNCH_TYPE_EC2,
-              help='ECS Launch type (default: EC2)')
-@click.option('--subnet', type=str, multiple=True,
-              help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
-@click.option('--securitygroup', type=str, multiple=True,
-              help='A security group ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
-@click.option('--public-ip', is_flag=True, default=False,
-              help='Should a public IP address be assigned to the task (default: False)')
-@click.option('--platform-version',
-              help='The version of the Fargate platform on which to run the task. Optional, FARGATE launch type only.',
-              required=False)
+@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--launchtype', type=click.Choice([LAUNCH_TYPE_EC2, LAUNCH_TYPE_FARGATE]), default=LAUNCH_TYPE_EC2, help='ECS Launch type (default: EC2)')
+@click.option('--subnet', type=str, multiple=True, help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
+@click.option('--securitygroup', type=str, multiple=True, help='A security group ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
+@click.option('--public-ip', is_flag=True, default=False, help='Should a public IP address be assigned to the task (default: False)')
+@click.option('--platform-version', help='The version of the Fargate platform on which to run the task. Optional, FARGATE launch type only.', required=False)
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
-@click.option('--exclusive-env', is_flag=True, default=False,
-              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
 def run(cluster, task, count, command, env, env_file, secret, launchtype, subnet, securitygroup, public_ip,
         platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, diff):

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -573,7 +573,7 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
     waiting_timeout = datetime.now() + timedelta(seconds=timeout)
     service = action.get_service()
     inspected_until = None
-    stopped_inspected_until = None
+    stopped_inspected_until = datetime.now()
     if timeout == -1:
         waiting = False
     else:

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -673,7 +673,7 @@ def inspect_stopped(tasks, failure_message, ignore_warnings, since):
     if not tasks:
         return last_error_timestamp
     for task in tasks:
-        timestamp = task['stoppingAt'].replace(tzinfo=None)
+        timestamp = task['createdAt'].replace(tzinfo=None)
         if since and timestamp > since:
             last_error_timestamp = timestamp
             continue

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -28,53 +28,96 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.argument('cluster')
 @click.argument('service')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
-@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
-@click.option('-h', '--health-check', type=(str, str, int, int, int, int), multiple=True, help='Overwrites the healthcheck in a container: <container> <command> <interval> <timeout> <retries> <start_period>')
-@click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
-@click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
-@click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the privileged value for a container: <container> <privileged>')
-@click.option('--essential', type=(str, bool), multiple=True, help='Overwrites the essential value for a container: <container> <essential>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
-@click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
-@click.option('-p', '--port', type=(str, int, int), multiple=True, help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-m', '--mount', type=(str, str, str), multiple=True, help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-l', '--log', type=(str, str, str, str), multiple=True, help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
+@click.option('-i', '--image', type=(str, str), multiple=True,
+              help='Overwrites the image for a container: <container> <image>')
+@click.option('-c', '--command', type=(str, str), multiple=True,
+              help='Overwrites the command in a container: <container> <command>')
+@click.option('-h', '--health-check', type=(str, str, int, int, int, int), multiple=True,
+              help='Overwrites the healthcheck in a container: <container> <command> <interval> <timeout> <retries> <start_period>')
+@click.option('--cpu', type=(str, int), multiple=True,
+              help='Overwrites the cpu value for a container: <container> <cpu>')
+@click.option('--memory', type=(str, int), multiple=True,
+              help='Overwrites the memory value for a container: <container> <memory>')
+@click.option('--memoryreservation', type=(str, int), multiple=True,
+              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--privileged', type=(str, bool), multiple=True,
+              help='Overwrites the privileged value for a container: <container> <privileged>')
+@click.option('--essential', type=(str, bool), multiple=True,
+              help='Overwrites the essential value for a container: <container> <essential>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True,
+              help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
+              help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True,
+              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True,
+              help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
+@click.option('--system-control', type=(str, str, str), multiple=True,
+              help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
+@click.option('-p', '--port', type=(str, int, int), multiple=True,
+              help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-m', '--mount', type=(str, str, str), multiple=True,
+              help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-l', '--log', type=(str, str, str, str), multiple=True,
+              help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('-x', '--execution-role', type=str, help='Sets the execution\'s role ARN: <execution role ARN>')
-@click.option('--task', type=str, help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
+@click.option('--task', type=str,
+              help='Task definition to be deployed. Can be a task ARN or a task family with optional revision')
 @click.option('--region', required=False, help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', required=False, help='AWS access key id')
 @click.option('--secret-access-key', required=False, help='AWS secret access key')
 @click.option('--profile', required=False, help='AWS configuration profile name')
-@click.option('--timeout', required=False, default=300, type=int, help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
-@click.option('--ignore-warnings', is_flag=True, help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
-@click.option('--newrelic-apikey', required=False, help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
-@click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
-@click.option('--newrelic-region', required=False, help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
-@click.option('--newrelic-revision', required=False, help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
+@click.option('--timeout', required=False, default=300, type=int,
+              help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
+@click.option('--ignore-warnings', is_flag=True,
+              help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
+@click.option('--newrelic-apikey', required=False,
+              help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
+@click.option('--newrelic-appid', required=False,
+              help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
+@click.option('--newrelic-region', required=False,
+              help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
+@click.option('--newrelic-revision', required=False,
+              help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
 @click.option('--comment', required=False, help='Description/comment for recording the deployment')
 @click.option('--user', required=False, help='User who executes the deployment (used for recording)')
-@click.option('--diff/--no-diff', default=True, help='Print which values were changed in the task definition (default: --diff)')
-@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
-@click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
-@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--sleep-time', default=1, type=int, help='Amount of seconds to wait between each check of the service (default: 1)')
-@click.option('--slack-url', required=False, help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
-@click.option('--slack-service-match', default=".*", required=False, help='A regular expression for defining, which services should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
-@click.option('--exclusive-ulimits', is_flag=True, default=False, help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
-@click.option('--exclusive-system-controls', is_flag=True, default=False, help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
-@click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
-@click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
-@click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
-@click.option('--add-container', type=str, multiple=True, required=False, help='Add a placeholder container in the task definition.')
-@click.option('--remove-container', type=str, multiple=True, required=False, help='Remove a container from the task definition.')
-def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, privileged, essential, env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, slack_service_match='.*'):
+@click.option('--diff/--no-diff', default=True,
+              help='Print which values were changed in the task definition (default: --diff)')
+@click.option('--deregister/--no-deregister', default=True,
+              help='Deregister or keep the old task definition (default: --deregister)')
+@click.option('--rollback/--no-rollback', default=False,
+              help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
+@click.option('--exclusive-env', is_flag=True, default=False,
+              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False,
+              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--sleep-time', default=1, type=int,
+              help='Amount of seconds to wait between each check of the service (default: 1)')
+@click.option('--slack-url', required=False,
+              help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
+@click.option('--slack-service-match', default=".*", required=False,
+              help='A regular expression for defining, which services should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
+@click.option('--exclusive-ulimits', is_flag=True, default=False,
+              help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
+@click.option('--exclusive-system-controls', is_flag=True, default=False,
+              help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
+@click.option('--exclusive-ports', is_flag=True, default=False,
+              help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
+@click.option('--exclusive-mounts', is_flag=True, default=False,
+              help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
+@click.option('--volume', type=(str, str), multiple=True, required=False,
+              help='Set volume mapping from host to container in the task definition.')
+@click.option('--add-container', type=str, multiple=True, required=False,
+              help='Add a placeholder container in the task definition.')
+@click.option('--remove-container', type=str, multiple=True, required=False,
+              help='Remove a container from the task definition.')
+def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, privileged, essential,
+           env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, task, region,
+           access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region,
+           newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env,
+           exclusive_secrets, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports,
+           exclusive_mounts, volume, add_container, remove_container, slack_url, slack_service_match='.*'):
     """
     Redeploy or modify a service.
 
@@ -92,7 +135,8 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
         deployment = DeployAction(client, cluster, service)
 
         td = get_task_definition(deployment, task)
-        # If there is a new container, add it at frist.
+        # If there is a new container, add it at fd
+
         td.add_containers(add_container)
         td.remove_containers(remove_container)
         td.set_images(tag, **{key: value for (key, value) in image})
@@ -163,46 +207,79 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.argument('cluster')
 @click.argument('task')
 @click.argument('rule')
-@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
+@click.option('-i', '--image', type=(str, str), multiple=True,
+              help='Overwrites the image for a container: <container> <image>')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
-@click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
-@click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
-@click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
-@click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
-@click.option('-p', '--port', type=(str, int, int), multiple=True, help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-m', '--mount', type=(str, str, str), multiple=True, help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
-@click.option('-l', '--log', type=(str, str, str, str), multiple=True, help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
+@click.option('-c', '--command', type=(str, str), multiple=True,
+              help='Overwrites the command in a container: <container> <command>')
+@click.option('--cpu', type=(str, int), multiple=True,
+              help='Overwrites the cpu value for a container: <container> <cpu>')
+@click.option('--memory', type=(str, int), multiple=True,
+              help='Overwrites the memory value for a container: <container> <memory>')
+@click.option('--memoryreservation', type=(str, int), multiple=True,
+              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--privileged', type=(str, bool), multiple=True,
+              help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True,
+              help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True,
+              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True,
+              help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
+@click.option('--system-control', type=(str, str, str), multiple=True,
+              help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
+@click.option('-p', '--port', type=(str, int, int), multiple=True,
+              help='Adds or changes a port mappings in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-m', '--mount', type=(str, str, str), multiple=True,
+              help='Adds or changes a mount points in the container description (Not available for Fargate): <container> <container port value> <host port value>')
+@click.option('-l', '--log', type=(str, str, str, str), multiple=True,
+              help='Adds or changes a log configuration in the container description (Not available for Fargate): <container> <log driver> <option name> <option value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
+              help='Load environment variables from .env-file')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('-x', '--execution-role', type=str, help='Sets the execution\'s role ARN: <execution role ARN>')
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
-@click.option('--newrelic-apikey', required=False, help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
-@click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
-@click.option('--newrelic-region', required=False, help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
-@click.option('--newrelic-revision', required=False, help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
+@click.option('--newrelic-apikey', required=False,
+              help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
+@click.option('--newrelic-appid', required=False,
+              help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
+@click.option('--newrelic-region', required=False,
+              help='New Relic region: US or EU (default: US). Can also be defined via environment variable NEW_RELIC_REGION')
+@click.option('--newrelic-revision', required=False,
+              help='New Relic revision for recording the deployment (default: --tag value). Can also be defined via environment variable NEW_RELIC_REVISION')
 @click.option('--comment', required=False, help='Description/comment for recording the deployment')
 @click.option('--user', required=False, help='User who executes the deployment (used for recording)')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
-@click.option('--rollback/--no-rollback', default=False, help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
-@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--slack-url', required=False, help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
-@click.option('--slack-service-match', default=".*", required=False, help='A regular expression for defining, deployments of which crons should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
-@click.option('--exclusive-ulimits', is_flag=True, default=False, help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
-@click.option('--exclusive-system-controls', is_flag=True, default=False, help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
-@click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
-@click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
-@click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
-def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, privileged, env, env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume):
+@click.option('--deregister/--no-deregister', default=True,
+              help='Deregister or keep the old task definition (default: --deregister)')
+@click.option('--rollback/--no-rollback', default=False,
+              help='Rollback to previous revision, if deployment failed (default: --no-rollback)')
+@click.option('--exclusive-env', is_flag=True, default=False,
+              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False,
+              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--slack-url', required=False,
+              help='Webhook URL of the Slack integration. Can also be defined via environment variable SLACK_URL')
+@click.option('--slack-service-match', default=".*", required=False,
+              help='A regular expression for defining, deployments of which crons should be notified. (default: .* =all). Can also be defined via environment variable SLACK_SERVICE_MATCH')
+@click.option('--exclusive-ulimits', is_flag=True, default=False,
+              help='Set the given ulimits exclusively and remove all other pre-existing ulimits from all containers')
+@click.option('--exclusive-system-controls', is_flag=True, default=False,
+              help='Set the given system controls exclusively and remove all other pre-existing system controls from all containers')
+@click.option('--exclusive-ports', is_flag=True, default=False,
+              help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
+@click.option('--exclusive-mounts', is_flag=True, default=False,
+              help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
+@click.option('--volume', type=(str, str), multiple=True, required=False,
+              help='Set volume mapping from host to container in the task definition.')
+def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, privileged, env, env_file, secret,
+         ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key,
+         newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister,
+         rollback, exclusive_env, exclusive_secrets, slack_url, slack_service_match, exclusive_ulimits,
+         exclusive_system_controls, exclusive_ports, exclusive_mounts, volume):
     """
     Update a scheduled task.
 
@@ -268,22 +345,31 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
 
 @click.command()
 @click.argument('task')
-@click.option('-i', '--image', type=(str, str), multiple=True, help='Overwrites the image for a container: <container> <image>')
+@click.option('-i', '--image', type=(str, str), multiple=True,
+              help='Overwrites the image for a container: <container> <image>')
 @click.option('-t', '--tag', help='Changes the tag for ALL container images')
-@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('-c', '--command', type=(str, str), multiple=True,
+              help='Overwrites the command in a container: <container> <command>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True,
+              help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
+              help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True,
+              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
-@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
-@click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
-def update(task, image, tag, command, env, env_file, secret, role, region, access_key_id, secret_access_key, profile, diff, exclusive_env, exclusive_secrets, deregister):
+@click.option('--exclusive-env', is_flag=True, default=False,
+              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False,
+              help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
+@click.option('--deregister/--no-deregister', default=True,
+              help='Deregister or keep the old task definition (default: --deregister)')
+def update(task, image, tag, command, env, env_file, secret, role, region, access_key_id, secret_access_key, profile,
+           diff, exclusive_env, exclusive_secrets, deregister):
     """
     Update a task definition.
 
@@ -324,10 +410,14 @@ def update(task, image, tag, command, env, env_file, secret, role, region, acces
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
-@click.option('--timeout', default=300, type=int, help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
-@click.option('--ignore-warnings', is_flag=True, help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
-@click.option('--sleep-time', default=1, type=int, help='Amount of seconds to wait between each check of the service (default: 1)')
-def scale(cluster, service, desired_count, access_key_id, secret_access_key, region, profile, timeout, ignore_warnings, sleep_time):
+@click.option('--timeout', default=300, type=int,
+              help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
+@click.option('--ignore-warnings', is_flag=True,
+              help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
+@click.option('--sleep-time', default=1, type=int,
+              help='Amount of seconds to wait between each check of the service (default: 1)')
+def scale(cluster, service, desired_count, access_key_id, secret_access_key, region, profile, timeout, ignore_warnings,
+          sleep_time):
     """
     Scale a service up or down.
 
@@ -364,22 +454,34 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.argument('cluster')
 @click.argument('task')
 @click.argument('count', required=False, default=1)
-@click.option('-c', '--command', type=(str, str), multiple=True, help='Overwrites the command in a container: <container> <command>')
-@click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
-@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
-@click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
-@click.option('--launchtype', type=click.Choice([LAUNCH_TYPE_EC2, LAUNCH_TYPE_FARGATE]), default=LAUNCH_TYPE_EC2, help='ECS Launch type (default: EC2)')
-@click.option('--subnet', type=str, multiple=True, help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
-@click.option('--securitygroup', type=str, multiple=True, help='A security group ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
-@click.option('--public-ip', is_flag=True, default=False, help='Should a public IP address be assigned to the task (default: False)')
-@click.option('--platform-version', help='The version of the Fargate platform on which to run the task. Optional, FARGATE launch type only.', required=False)
+@click.option('-c', '--command', type=(str, str), multiple=True,
+              help='Overwrites the command in a container: <container> <command>')
+@click.option('-e', '--env', type=(str, str, str), multiple=True,
+              help='Adds or changes an environment variable: <container> <name> <value>')
+@click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False,
+              help='Load environment variables from .env-file')
+@click.option('-s', '--secret', type=(str, str, str), multiple=True,
+              help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--launchtype', type=click.Choice([LAUNCH_TYPE_EC2, LAUNCH_TYPE_FARGATE]), default=LAUNCH_TYPE_EC2,
+              help='ECS Launch type (default: EC2)')
+@click.option('--subnet', type=str, multiple=True,
+              help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
+@click.option('--securitygroup', type=str, multiple=True,
+              help='A security group ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
+@click.option('--public-ip', is_flag=True, default=False,
+              help='Should a public IP address be assigned to the task (default: False)')
+@click.option('--platform-version',
+              help='The version of the Fargate platform on which to run the task. Optional, FARGATE launch type only.',
+              required=False)
 @click.option('--region', help='AWS region (e.g. eu-central-1)')
 @click.option('--access-key-id', help='AWS access key id')
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
-@click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-env', is_flag=True, default=False,
+              help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-def run(cluster, task, count, command, env, env_file, secret, launchtype, subnet, securitygroup, public_ip, platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, diff):
+def run(cluster, task, count, command, env, env_file, secret, launchtype, subnet, securitygroup, public_ip,
+        platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, diff):
     """
     Run a one-off task.
 
@@ -471,7 +573,7 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
     waiting_timeout = datetime.now() + timedelta(seconds=timeout)
     service = action.get_service()
     inspected_until = None
-
+    stopped_inspected_until = None
     if timeout == -1:
         waiting = False
     else:
@@ -487,6 +589,14 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
             since=inspected_until,
             timeout=False
         )
+
+        stopped_inspected_until = inspect_stopped(
+            tasks=action.get_stopped_tasks(service),
+            failure_message=failure_message,
+            ignore_warnings=ignore_warnings,
+            since=stopped_inspected_until
+        )
+
         waiting = not action.is_deployed(service)
 
         if waiting:
@@ -652,6 +762,42 @@ def inspect_errors(service, failure_message, ignore_warnings, since, timeout):
         failure_message += ' due to timeout. Please see: ' \
                            'https://github.com/fabfuel/ecs-deploy#timeout'
         click.secho('')
+
+    if error:
+        raise TaskPlacementError(failure_message)
+
+    return last_error_timestamp
+
+
+def inspect_stopped(tasks, failure_message, ignore_warnings, since):
+    error = False
+    last_error_timestamp = since
+    if not tasks:
+        return last_error_timestamp
+    for task in tasks:
+        timestamp = task['stoppingAt'].replace(tzinfo=None)
+        if since and timestamp < since:
+            last_error_timestamp = timestamp
+            continue
+        if task['stopCode'] == 'ServiceSchedulerInitiated':
+            last_error_timestamp = timestamp
+            continue
+        click.secho('')
+        if ignore_warnings:
+            last_error_timestamp = timestamp
+            click.secho(
+                '%s\nWARNING: %s' % (timestamp, task['stopCode']),
+                fg='yellow',
+                err=False
+            )
+            click.secho('Continuing.', nl=False)
+        else:
+            click.secho(
+                '%s\nERROR: %s\n' % (timestamp, task['stopCode']),
+                fg='red',
+                err=True
+            )
+            error = True
 
     if error:
         raise TaskPlacementError(failure_message)

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -674,7 +674,7 @@ def inspect_stopped(tasks, failure_message, ignore_warnings, since):
         return last_error_timestamp
     for task in tasks:
         timestamp = task['stoppingAt'].replace(tzinfo=None)
-        if since and timestamp < since:
+        if since and timestamp > since:
             last_error_timestamp = timestamp
             continue
         if task['stopCode'] == 'ServiceSchedulerInitiated':

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -379,8 +379,7 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-def run(cluster, task, count, command, env, env_file, secret, launchtype, subnet, securitygroup, public_ip,
-        platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, diff):
+def run(cluster, task, count, command, env, env_file, secret, launchtype, subnet, securitygroup, public_ip, platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, diff):
     """
     Run a one-off task.
 

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -76,6 +76,13 @@ class EcsClient(object):
             serviceName=service_name
         )
 
+    def list_stopped_tasks(self, cluster_name, service_name):
+        return self.boto.list_tasks(
+            cluster=cluster_name,
+            serviceName=service_name,
+            desiredStatus='STOPPED'
+        )
+
     def describe_tasks(self, cluster_name, task_arns):
         return self.boto.describe_tasks(cluster=cluster_name, tasks=task_arns)
 
@@ -269,6 +276,11 @@ class EcsService(dict):
             if since < event[u'createdAt'] < until:
                 errors[event[u'createdAt']] = event[u'message']
         return errors
+
+
+
+
+
 
 
 class EcsTaskDefinition(object):
@@ -1193,6 +1205,15 @@ class EcsAction(object):
             if arn == service.task_definition and status == u'RUNNING':
                 running_count += 1
         return running_count
+
+    def get_stopped_tasks(self, service):
+        stopped_tasks = self._client.list_stopped_tasks(
+            cluster_name=service.cluster,
+            service_name=service.name
+        )
+        if stopped_tasks["taskArns"]:
+            return self._client.describe_tasks(cluster_name=self._cluster_name, task_arns=stopped_tasks["taskArns"])["tasks"]
+
 
     @property
     def client(self):


### PR DESCRIPTION
add inspection for stopped tasks. breaking deployment when tasks are stopped. this is a scenario I encounter very often. 
'ecs deploy' doesn't handle errors like 'EssentialContainerExited ' and we are forced to go to the UI to know why deployment failed,

after this change deploying a bad task with a bad container will end by:
```

Updating service
Successfully changed task definition to: xxxxxxxx:159

Deploying new task definition................................................................................................
2021-06-16 10:55:44.967000
ERROR: EssentialContainerExited

Deployment failed
```