### PR TITLE
Relax click version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 
 dependencies = [
-    'click==7.1.2',
+    'click>=7.1.2, <9',
     'click-log==0.3.2',
     'botocore>=1.17.47',
     'boto3>=1.14.47',


### PR DESCRIPTION
This PR relaxes the version constraint of the `click` dependency so that versions above `8.0` can be installed. We had to update the version of `celery` that our app was using (previously `5.0.5`) because of a critical security alert. We upgraded to `celery 5.2.2` which requires `click >=8.0,<9.0` but because `ecs-deploy` had locked `click` to `7.1.2`, we could not do this.