### PR TITLE
new feature: cpu and memory configurable at task level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ ECS Deploy
 .. image:: https://github.com/fabfuel/ecs-deploy/actions/workflows/build.yml/badge.svg
     :target: https://github.com/fabfuel/ecs-deploy/actions/workflows/build.yml
 
-`ecs-deploy` simplifies deployments on Amazon ECS by providing a convinience CLI tool for complex actions, which are executed pretty often.
+`ecs-deploy` simplifies deployments on Amazon ECS by providing a convenience CLI tool for complex actions, which are executed pretty often.
 
 Key Features
 ------------
@@ -45,7 +45,7 @@ Update a task definition (without running or deploying)::
 Installation
 ------------
 
-The project is availably on PyPI. Simply run::
+The project is available on PyPI. Simply run::
 
     $ pip install ecs-deploy
 
@@ -143,7 +143,7 @@ Deployment
 
 Simple Redeploy
 ===============
-To redeploy a service without any modifications, but pulling the most recent image versions, run the follwing command.
+To redeploy a service without any modifications, but pulling the most recent image versions, run the following command.
 This will duplicate the current task definition and cause the service to redeploy all running tasks.::
 
     $ ecs deploy my-cluster my-service
@@ -295,7 +295,7 @@ To change the command of a specific container, run the following command::
     $ ecs deploy my-cluster my-service --command webserver "nginx"
 
 This will modify the **webserver** container and change its command to "nginx". If you have 
-a command that requries arugments as well, then you can simply specify it like this as you would normally do:
+a command that requires arguments as well, then you can simply specify it like this as you would normally do:
 
     $ ecs deploy my-cluster my-service --command webserver "ngnix -c /etc/ngnix/ngnix.conf"
 
@@ -321,13 +321,15 @@ This will set the task role to "MySpecialEcsTaskRole".
 
 Set CPU and memory reservation
 ==============================
-- Set the `cpu` value for a task definition: :code:`--cpu <container_name> 0`.
-- Set the `memory` value (`hard limit`) for a task definition: :code:`--memory <container_name> 256`.
+- Set the `cpu` value for a task: :code:`--task-cpu 0`.
+- Set the `cpu` value for a task container: :code:`--cpu <container_name> 0`.
+- Set the `memory` value (`hard limit`) for a task: :code:`--task-memory 256`.
+- Set the `memory` value (`hard limit`) for a task container: :code:`--memory <container_name> 256`.
 - Set the `memoryreservation` value (`soft limit`) for a task definition: :code:`--memoryreservation <container_name> 256`.
 
 Set privileged or essential flags
 =================================
-- Set the `privliged` value for a task definition: :code:`--privileged <container_name> True|False`.
+- Set the `privileged` value for a task definition: :code:`--privileged <container_name> True|False`.
 - Set the `essential` value for a task definition: :code:`--essential <container_name> True|False`.
 
 Set logging configuration
@@ -374,7 +376,7 @@ Placeholder Container
 =====================
 - Add placeholder containers: :code:`--add-container <container_name>`.
 - To comply with the minimum requirements for a task definition, a placeholder container is set like this:
-    + The contaienr name is :code:`<container_name>`.
+    + The container name is :code:`<container_name>`.
     + The container image is :code:`PLACEHOLDER`.
     + The container soft limit is :code:`128`.
 - The idea is to set sensible values with the deployment.
@@ -497,7 +499,7 @@ Optionally you can provide additional information for the deployment:
 
 - ``--comment "New feature X"`` - comment to the deployment
 - ``--user john.doe`` - the name of the user who deployed with
-- ``--newrelic-revision 1.0.0`` - explicitly set the revison to use for the deployment
+- ``--newrelic-revision 1.0.0`` - explicitly set the revision to use for the deployment
 
 Note: If neither ``--tag`` nor ``--newrelic-revision`` are provided, the deployment will not be recorded.
 

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -34,6 +34,8 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
 @click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
 @click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--task-cpu', type=int, help='Overwrites the cpu value for a task: <cpu>')
+@click.option('--task-memory', type=int, help='Overwrites the memory value for a task: <memory>')
 @click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the privileged value for a container: <container> <privileged>')
 @click.option('--essential', type=(str, bool), multiple=True, help='Overwrites the essential value for a container: <container> <essential>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
@@ -79,7 +81,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
 @click.option('--add-container', type=str, multiple=True, required=False, help='Add a placeholder container in the task definition.')
 @click.option('--remove-container', type=str, multiple=True, required=False, help='Remove a container from the task definition.')
-def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, privileged, essential, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
+def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, essential, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
     """
     Redeploy or modify a service.
 
@@ -105,6 +107,8 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
         td.set_cpu(**{key: value for (key, value) in cpu})
         td.set_memory(**{key: value for (key, value) in memory})
         td.set_memoryreservation(**{key: value for (key, value) in memoryreservation})
+        td.set_task_cpu(task_cpu)
+        td.set_task_memory(task_memory)
         td.set_privileged(**{key: value for (key, value) in privileged})
         td.set_essential(**{key: value for (key, value) in essential})
         td.set_environment(env, exclusive_env, env_file)
@@ -176,6 +180,8 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.option('--cpu', type=(str, int), multiple=True, help='Overwrites the cpu value for a container: <container> <cpu>')
 @click.option('--memory', type=(str, int), multiple=True, help='Overwrites the memory value for a container: <container> <memory>')
 @click.option('--memoryreservation', type=(str, int), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
+@click.option('--task-cpu', type=int, help='Overwrites the cpu value for a task: <cpu>')
+@click.option('--task-memory', type=int, help='Overwrites the memory value for a task: <memory>')
 @click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
@@ -213,7 +219,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
 @click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
 @click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
-def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, privileged, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, docker_label, exclusive_docker_labels):
+def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, docker_label, exclusive_docker_labels):
     """
     Update a scheduled task.
 
@@ -234,6 +240,8 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
         td.set_cpu(**{key: value for (key, value) in cpu})
         td.set_memory(**{key: value for (key, value) in memory})
         td.set_memoryreservation(**{key: value for (key, value) in memoryreservation})
+        td.set_task_cpu(task_cpu)
+        td.set_task_memory(task_memory)
         td.set_privileged(**{key: value for (key, value) in privileged})
         td.set_environment(env, exclusive_env, env_file)
         td.set_docker_labels(docker_label, exclusive_docker_labels)

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -840,6 +840,16 @@ def test_task_set_mount_points(task_definition):
     assert {'sourceVolume': 'volume', 'containerPath': '/data/path', 'readOnly': False} in task_definition.containers[0]['mountPoints']
     assert {'sourceVolume': 'another_volume', 'containerPath': '/logs/path', 'readOnly': False} in task_definition.containers[0]['mountPoints']
 
+def test_task_set_task_cpu(task_definition):
+    assert task_definition.cpu is None
+    task_definition.set_task_cpu(256)
+    assert task_definition.cpu == '256'
+
+def test_task_set_task_memory(task_definition):
+    assert task_definition.memory is None
+    task_definition.set_task_memory(1024)
+    assert task_definition.memory == '1024'
+
 def test_task_set_mount_points_exclusively(task_definition):
     assert len(task_definition.containers[0]['mountPoints']) == 1
     assert '/container/path' == task_definition.containers[0]['mountPoints'][0]['containerPath']
@@ -1105,7 +1115,9 @@ def test_client_register_task_definition(client):
         status='active',
         taskDefinitionArn='arn:task',
         requiresAttributes={},
-        unkownProperty='foobar'
+        unkownProperty='foobar',
+        cpu=256,
+        memory=1024
     )
 
     client.register_task_definition(
@@ -1116,7 +1128,9 @@ def test_client_register_task_definition(client):
         execution_role_arn=execution_role_arn,
         runtime_platform=task_definition.runtime_platform,
         tags=task_definition.tags,
-        additional_properties=task_definition.additional_properties
+        additional_properties=task_definition.additional_properties,
+        cpu=256,
+        memory=1024
     )
 
     client.boto.register_task_definition.assert_called_once_with(
@@ -1127,7 +1141,9 @@ def test_client_register_task_definition(client):
         executionRoleArn=execution_role_arn,
         runtimePlatform=runtime_platform,
         tags=task_definition.tags,
-        unkownProperty='foobar'
+        unkownProperty='foobar',
+        cpu=256,
+        memory=1024
     )
 
 
@@ -1160,7 +1176,9 @@ def test_client_register_task_definition_without_tags(client):
         execution_role_arn=execution_role_arn,
         runtime_platform=task_definition.runtime_platform,
         tags=task_definition.tags,
-        additional_properties=task_definition.additional_properties
+        additional_properties=task_definition.additional_properties,
+        cpu=256,
+        memory=1024
     )
 
     client.boto.register_task_definition.assert_called_once_with(
@@ -1170,7 +1188,9 @@ def test_client_register_task_definition_without_tags(client):
         taskRoleArn=role_arn,
         executionRoleArn=execution_role_arn,
         runtimePlatform=runtime_platform,
-        unkownProperty='foobar'
+        unkownProperty='foobar',
+        cpu=256,
+        memory=1024
     )
 
 
@@ -1291,7 +1311,9 @@ def test_update_task_definition(client, task_definition):
             u'networkMode': u'host',
             u'placementConstraints': {},
             u'unknownProperty': u'lorem-ipsum'
-        }
+        },
+        cpu=None,
+        memory=None
     )
 
 
@@ -1603,7 +1625,7 @@ class EcsTestClient(object):
         return deepcopy(RESPONSE_DESCRIBE_TASKS)
 
     def register_task_definition(self, family, containers, volumes, role_arn,
-                                 execution_role_arn, runtime_platform, tags, additional_properties):
+                                 execution_role_arn, runtime_platform, tags, cpu, memory, additional_properties):
         if not self.access_key_id or not self.secret_access_key:
             raise EcsConnectionError(u'Unable to locate credentials. Configure credentials by running "aws configure".')
         return deepcopy(RESPONSE_TASK_DEFINITION_2)


### PR DESCRIPTION
Currently cpu and memory can only be set per-container. This makes it possible to set it at the task level.