### PR TITLE
Add --secrets-env-file option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,22 @@ Instead of setting environment variables separately, you can pass a .env file pe
 
     $ ecs deploy my-cluster my-service --s3-env-file my-app arn:aws:s3:::my-ecs-environment/my-app.env
 
+Set secrets via .env files
+==============================
+Instead of setting secrets separately, you can pass a .env file per container to set all secrets at once.
+
+This will expect an env file format, but any values will be set as the `valueFrom` parameter in the secrets config.
+This value can be either the path or the full ARN of a secret in the AWS Parameter Store. For example, with a secrets.env
+file like the following:
+
+```
+SOME_SECRET=arn:aws:ssm:<aws region>:<aws account id>:parameter/KEY_OF_SECRET_IN_PARAMETER_STORE
+```
+
+$ ecs deploy my-cluster my-service --secret-env-file webserver env/secrets.env
+
+This will modify the **webserver** container definition and add or overwrite the environment variable `SOME_SECRET` with the value of the `KEY_OF_SECRET_IN_PARAMETER_STORE` in the AWS Parameter Store of the AWS Systems Manager.
+
 
 Set a docker label
 ===================

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -42,6 +42,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file: <container> <env file path>')
 @click.option('--s3-env-file', type=(str, str), multiple=True, required=False, help='Location of .env-file in S3 in ARN format (eg arn:aws:s3:::/bucket_name/object_name): <container> <S3 ARN>')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--secrets-env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load secrets from .env-file: <container> <env file path>')
 @click.option('-d', '--docker-label', type=(str, str, str), multiple=True, help='Adds or changes a docker label: <container> <name> <value>')
 @click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
 @click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -82,7 +82,7 @@ def get_client(access_key_id, secret_access_key, region, profile):
 @click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
 @click.option('--add-container', type=str, multiple=True, required=False, help='Add a placeholder container in the task definition.')
 @click.option('--remove-container', type=str, multiple=True, required=False, help='Remove a container from the task definition.')
-def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, essential, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
+def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, essential, env, env_file, s3_env_file, secret, secrets_env_file, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
     """
     Redeploy or modify a service.
 
@@ -115,7 +115,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
         td.set_environment(env, exclusive_env, env_file)
         td.set_docker_labels(docker_label, exclusive_docker_labels)
         td.set_s3_env_file(s3_env_file, exclusive_s3_env_file)
-        td.set_secrets(secret, exclusive_secrets)
+        td.set_secrets(secret, exclusive_secrets, secrets_env_file)
         td.set_ulimits(ulimit, exclusive_ulimits)
         td.set_system_controls(system_control, exclusive_system_controls)
         td.set_port_mappings(port, exclusive_ports)
@@ -186,6 +186,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.option('--privileged', type=(str, bool), multiple=True, help='Overwrites the memory reservation value for a container: <container> <memoryreservation>')
 @click.option('-e', '--env', type=(str, str, str), multiple=True, help='Adds or changes an environment variable: <container> <name> <value>')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--secrets-env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load secrets from .env-file: <container> <env file path>')
 @click.option('-d', '--docker-label', type=(str, str, str), multiple=True, help='Adds or changes a docker label: <container> <name> <value>')
 @click.option('-u', '--ulimit', type=(str, str, int, int), multiple=True, help='Adds or changes a ulimit variable in the container description (Not available for Fargate): <container> <ulimit name> <softlimit value> <hardlimit value>')
 @click.option('--system-control', type=(str, str, str), multiple=True, help='Adds or changes a system control variable in the container description (Not available for Fargate): <container> <namespace> <value>')
@@ -220,7 +221,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
 @click.option('--exclusive-ports', is_flag=True, default=False, help='Set the given port mappings exclusively and remove all other pre-existing port mappings from all containers')
 @click.option('--exclusive-mounts', is_flag=True, default=False, help='Set the given mount points exclusively and remove all other pre-existing mount points from all containers')
 @click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
-def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, env, env_file, s3_env_file, secret, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, docker_label, exclusive_docker_labels):
+def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, env, env_file, s3_env_file, secret, secrets_env_file, ulimit, system_control, port, mount, log, role, execution_role, region, access_key_id, secret_access_key, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, profile, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, slack_url, slack_service_match, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, docker_label, exclusive_docker_labels):
     """
     Update a scheduled task.
 
@@ -247,7 +248,7 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
         td.set_environment(env, exclusive_env, env_file)
         td.set_docker_labels(docker_label, exclusive_docker_labels)
         td.set_s3_env_file(s3_env_file, exclusive_s3_env_file)
-        td.set_secrets(secret, exclusive_secrets)
+        td.set_secrets(secret, exclusive_secrets, secrets_env_file)
         td.set_ulimits(ulimit, exclusive_ulimits)
         td.set_system_controls(system_control, exclusive_system_controls)
         td.set_port_mappings(port, exclusive_ports)
@@ -297,6 +298,7 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
 @click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
 @click.option('--s3-env-file', type=(str, str), multiple=True, required=False, help='Location of .env-file in S3 in ARN format (eg arn:aws:s3:::/bucket_name/object_name')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--secrets-env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load secrets from .env-file: <container> <env file path>')
 @click.option('-d', '--docker-label', type=(str, str, str), multiple=True, help='Adds or changes a docker label: <container> <name> <value>')
 @click.option('-r', '--role', type=str, help='Sets the task\'s role ARN: <task role ARN>')
 @click.option('--runtime-platform', type=str, nargs=2, help='Overwrites runtimePlatform: <cpuArchitecture> <operatingSystemFamily>')
@@ -310,7 +312,7 @@ def cron(cluster, task, rule, image, tag, command, cpu, memory, memoryreservatio
 @click.option('--exclusive-docker-labels', is_flag=True, default=False, help='Set the given docker labels exclusively and remove all other pre-existing docker-labels from all containers')
 @click.option('--exclusive-s3-env-file', is_flag=True, default=False, help='Set the given s3 env files exclusively and remove all other pre-existing s3 env files from all containers')
 @click.option('--deregister/--no-deregister', default=True, help='Deregister or keep the old task definition (default: --deregister)')
-def update(task, image, tag, command, env, env_file, s3_env_file, secret, role, region, access_key_id, secret_access_key, profile, diff, exclusive_env, exclusive_s3_env_file, exclusive_secrets, runtime_platform, deregister, docker_label, exclusive_docker_labels):
+def update(task, image, tag, command, env, env_file, s3_env_file, secret, secrets_env_file, role, region, access_key_id, secret_access_key, profile, diff, exclusive_env, exclusive_s3_env_file, exclusive_secrets, runtime_platform, deregister, docker_label, exclusive_docker_labels):
     """
     Update a task definition.
 
@@ -328,7 +330,7 @@ def update(task, image, tag, command, env, env_file, s3_env_file, secret, role, 
         td.set_commands(**{key: value for (key, value) in command})
         td.set_environment(env, exclusive_env, env_file)
         td.set_docker_labels(docker_label, exclusive_docker_labels)
-        td.set_secrets(secret, exclusive_secrets)
+        td.set_secrets(secret, exclusive_secrets, secrets_env_file)
         td.set_s3_env_file(s3_env_file, exclusive_s3_env_file)
         td.set_role_arn(role)
         td.set_runtime_platform(runtime_platform)
@@ -399,6 +401,7 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.option('--env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load environment variables from .env-file')
 @click.option('--s3-env-file', type=(str, str), multiple=True, required=False, help='Location of .env-file in S3 in ARN format (eg arn:aws:s3:::/bucket_name/object_name')
 @click.option('-s', '--secret', type=(str, str, str), multiple=True, help='Adds or changes a secret environment variable from the AWS Parameter Store (Not available for Fargate): <container> <name> <parameter name>')
+@click.option('--secrets-env-file', type=(str, str), default=((None, None),), multiple=True, required=False, help='Load secrets from .env-file: <container> <env file path>')
 @click.option('-d', '--docker-label', type=(str, str, str), multiple=True, help='Adds or changes a docker label: <container> <name> <value>')
 @click.option('--launchtype', type=click.Choice([LAUNCH_TYPE_EC2, LAUNCH_TYPE_FARGATE]), default=LAUNCH_TYPE_EC2, help='ECS Launch type (default: EC2)')
 @click.option('--subnet', type=str, multiple=True, help='A subnet ID to launch the task within. Required for launch type FARGATE (multiple values possible)')
@@ -410,10 +413,11 @@ def scale(cluster, service, desired_count, access_key_id, secret_access_key, reg
 @click.option('--secret-access-key', help='AWS secret access key')
 @click.option('--profile', help='AWS configuration profile name')
 @click.option('--exclusive-env', is_flag=True, default=False, help='Set the given environment variables exclusively and remove all other pre-existing env variables from all containers')
+@click.option('--exclusive-secrets', is_flag=True, default=False, help='Set the given secrets exclusively and remove all other pre-existing secrets from all containers')
 @click.option('--exclusive-docker-labels', is_flag=True, default=False, help='Set the given docker labels exclusively and remove all other pre-existing docker-labels from all containers')
 @click.option('--exclusive-s3-env-file', is_flag=True, default=False, help='Set the given s3 env files exclusively and remove all other pre-existing s3 env files from all containers')
 @click.option('--diff/--no-diff', default=True, help='Print what values were changed in the task definition')
-def run(cluster, task, count, command, env, env_file, s3_env_file, secret, launchtype, subnet, securitygroup, public_ip, platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, exclusive_s3_env_file, diff, docker_label, exclusive_docker_labels):
+def run(cluster, task, count, command, env, env_file, s3_env_file, secret, secrets_env_file, launchtype, subnet, securitygroup, public_ip, platform_version, region, access_key_id, secret_access_key, profile, exclusive_env, exclusive_secrets, exclusive_s3_env_file, diff, docker_label, exclusive_docker_labels):
     """
     Run a one-off task.
 
@@ -431,7 +435,7 @@ def run(cluster, task, count, command, env, env_file, s3_env_file, secret, launc
         td.set_environment(env, exclusive_env, env_file)
         td.set_docker_labels(docker_label, exclusive_docker_labels)
         td.set_s3_env_file(s3_env_file, exclusive_s3_env_file)
-        td.set_secrets(secret)
+        td.set_secrets(secret, exclusive_secrets, secrets_env_file)
 
         if diff:
             print_diff(td, 'Using task definition: %s' % task)

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -758,8 +758,13 @@ class EcsTaskDefinition(object):
             {"value": e, "type": "s3"} for e in merged
         ]
 
-    def set_secrets(self, secrets_list, exclusive=False):
+    def set_secrets(self, secrets_list, exclusive=False, env_file=((None, None),)):
         secrets = defaultdict(dict)
+
+        if None not in env_file[0]:
+            for secret in env_file:
+                l = read_env_file(secret[0], secret[1])
+                secrets_list = l + secrets_list
 
         for secret in secrets_list:
             secrets[secret[0]][secret[1]] = secret[2]

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -745,6 +745,41 @@ def test_task_set_secrets(task_definition):
     assert {'name': 'foo', 'valueFrom': 'baz'} in task_definition.containers[0]['secrets']
     assert {'name': 'some-name', 'valueFrom': 'some-value'} in task_definition.containers[0]['secrets']
 
+def test_task_set_secrets_from_env_file(task_definition):
+    assert len(task_definition.containers[0]['secrets']) == 2
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write(b'some-secret-name-from-env-file=some-secret-value-from-env-file')
+    tmp.read()
+
+    task_definition.set_secrets((), env_file=((u'webserver',tmp.name),))
+    os.unlink(tmp.name)
+    tmp.close()
+
+    assert len(task_definition.containers[0]['secrets']) == 3
+
+    assert {"name": "baz", "valueFrom": "qux"} in task_definition.containers[0]['secrets']
+    assert {'name': 'some-secret-name-from-env-file', 'valueFrom': 'some-secret-value-from-env-file'} in task_definition.containers[0]['secrets']
+
+def test_task_set_secrets_from_s_and_env_file(task_definition):
+    assert len(task_definition.containers[0]['secrets']) == 2
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write(b'some-secret-name-from-env-file=some-secret-value-from-env-file')
+    tmp.read()
+
+    task_definition.set_secrets(((u'webserver', u'foo', u'baz'), (u'webserver', u'some-name', u'some-value')), env_file=((u'webserver',tmp.name),))
+    os.unlink(tmp.name)
+    tmp.close()
+
+    assert len(task_definition.containers[0]['secrets']) == 5
+
+    assert {"name": "baz", "valueFrom": "qux"} in task_definition.containers[0]['secrets']
+    assert {'name': 'dolor', 'valueFrom': 'sit'} in task_definition.containers[0]['secrets']
+    assert {'name': 'foo', 'valueFrom': 'baz'} in task_definition.containers[0]['secrets']
+    assert {"name": "baz", "valueFrom": "qux"} in task_definition.containers[0]['secrets']
+    assert {'name': 'some-secret-name-from-env-file', 'valueFrom': 'some-secret-value-from-env-file'} in task_definition.containers[0]['secrets']
+
 def test_task_set_system_controls(task_definition):
     assert len(task_definition.containers[0]['systemControls']) == 1
     


### PR DESCRIPTION
This PR adds a new option, `--secrets-env-file`, which works in essentially the same way as `--env-file` but adds the key/value pairs from this file into the secrets in the task definition instead of the environment.

The goal here is to allow users to use files like the below:

```
ENV_SECRET=arn:aws:ssm:eu-west-1:1234567890:parameter/app/secret
```

which will result in secrets being added to the task definition in the format:

```
{ name: "ENV_SECRET",  valueFrom: "arn:aws:ssm:eu-west-1:1234567890:parameter/app/secret" }
```

This means, alongside a `.env` file, a single deploy can contain all the secrets and environment variables needed to configure an application correctly. 