### PR TITLE
drop python 2.7 from ci matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- python 2.7 is not supported anymore in `actions/setup-python`
- dropping it from ci matrix which currently fails with `2.7`

references:
- pip: https://pip.pypa.io/en/latest/development/release-process/#python-2-support
- actions/setup-python: https://github.com/actions/setup-python/issues/672