### PR TITLE
Support multiple deploy actions

### DIFF
--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -100,7 +100,7 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
         client = get_client(access_key_id, secret_access_key, region, profile, account, assume_role)
         deployment = DeployAction(client, cluster, service)
 
-        td = get_task_definition(deployment, task)
+        td = deployment.get_task_definition(task)
         # If there is a new container, add it at frist.
         td.add_containers(add_container)
         td.remove_containers(remove_container)
@@ -558,14 +558,6 @@ def deploy_task_definition(deployment, task_definition, title, success_message,
 
     if deregister:
         deregister_task_definition(deployment, previous_task_definition)
-
-
-def get_task_definition(action, task):
-    if task:
-        task_definition = action.get_task_definition(task)
-    else:
-        task_definition = action.get_current_task_definition(action.service)
-    return task_definition
 
 
 def create_task_definition(action, task_definition):

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -1331,10 +1331,11 @@ class EcsAction(object):
             service_definition=services_definition[u'services'][0]
         )
 
-    def get_current_task_definition(self, service):
-        return self.get_task_definition(service.task_definition)
 
     def get_task_definition(self, task_definition):
+        if not task_definition:
+            task_definition = self._service.task_definition
+
         task_definition_payload = self._client.describe_task_definition(
             task_definition_arn=task_definition
         )

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import re
 import copy
@@ -1424,18 +1424,78 @@ class EcsAction(object):
         return self._service_name
 
 
-class DeployAction(EcsAction):
+class TrackableProgress:
+    def init_progresstracker(self):
+        self.start_timestamp = datetime.now()
+        self.stop_timestamp = None
+        self.inspected_until = None
+
+    def has_finished(self, timeout, failure_message, ignore_warnings):
+        waiting_timeout = self.start_timestamp + timedelta(seconds=timeout)
+        if datetime.now() > waiting_timeout:
+            raise TaskPlacementError(failure_message + " due to timeout. Please see: https://github.com/fabfuel/ecs-deploy#timeout")
+
+        service = self.get_service()
+        self.inspect_warnings(service, failure_message, ignore_warnings)
+
+        has_finished = self.is_deployed(service)
+
+        if has_finished:
+            self.stop_timestamp = datetime.now()
+        return has_finished
+
+    def inspect_warnings(self, service, failure_message, ignore_warnings):
+
+        warnings = service.get_warnings(self.inspected_until)
+        if not warnings:
+            return
+
+        if ignore_warnings:
+            logger.warning('')
+        else:
+            logger.error('')
+
+        error = False
+
+        for timestamp in warnings:
+            message = warnings[timestamp]
+            if ignore_warnings:
+                self.inspected_until = timestamp
+                logger.warning('%s: %s' % (timestamp, message))
+                logger.warning('Continuing.')
+            else:
+                error = True
+                logger.error('%s: %s' % (timestamp, message))
+
+        if service.older_errors:
+            logger.error('')
+            logger.error('Older errors')
+            for timestamp in service.older_errors:
+                logger.error('%s: %s' % (timestamp, service.older_errors[timestamp]))
+
+        if error:
+            raise TaskPlacementError(failure_message)
+
+    def get_duration(self):
+        if not self.stop_timestamp:
+            raise ValueError("Action not finished yet.")
+        return (self.stop_timestamp - self.start_timestamp).seconds
+
+
+class DeployAction(TrackableProgress, EcsAction):
     def deploy(self, task_definition):
         try:
             self._service.set_task_definition(task_definition)
+            self.init_progresstracker()
             return self.update_service(self._service)
         except ClientError as e:
             raise EcsError(str(e))
 
 
-class ScaleAction(EcsAction):
+class ScaleAction(TrackableProgress, EcsAction):
     def scale(self, desired_count):
         try:
+            self.init_progresstracker()
             return self.update_service(self._service, desired_count)
         except ClientError as e:
             raise EcsError(str(e))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 
 import pytest
@@ -244,7 +245,7 @@ def test_deploy_one_new_health_check(get_client, cmd_input, cmd_expected, runner
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
     assert u'Deployment successful' in result.output
-    
+
 
 
 @patch('ecs_deploy.cli.get_client')
@@ -635,8 +636,7 @@ def test_deploy_with_errors(get_client, runner):
     result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME))
     assert result.exit_code == 1
     assert u"Deployment failed" in result.output
-    assert u"ERROR: Service was unable to Lorem Ipsum" in result.output
-
+    assert re.search("error: [0-9-: \\.+]+Service was unable to Lorem Ipsum", result.output)
 
 @patch('ecs_deploy.cli.get_client')
 def test_deploy_with_client_errors(get_client, runner):
@@ -657,7 +657,7 @@ def test_deploy_ignore_warnings(get_client, runner):
     assert u'Successfully created revision: 2' in result.output
     assert u'Successfully deregistered revision: 1' in result.output
     assert u'Successfully changed task definition to: test-task:2' in result.output
-    assert u"WARNING: Service was unable to Lorem Ipsum" in result.output
+    assert re.search("warning: [0-9-: \\.+]+Service was unable to Lorem Ipsum", result.output)
     assert u"Continuing." in result.output
     assert u'Deployment successful' in result.output
 
@@ -781,7 +781,7 @@ def test_deploy_with_wait_within_timeout(get_client, runner):
     result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '--timeout', '10'))
     assert result.exit_code == 0
     assert u'Deploying new task definition' in result.output
-    assert u'...' in result.output
+    assert u'..' in result.output
 
 
 @patch('ecs_deploy.cli.get_client')
@@ -849,7 +849,7 @@ def test_scale_with_errors(get_client, runner):
     result = runner.invoke(cli.scale, (CLUSTER_NAME, SERVICE_NAME, '2'))
     assert result.exit_code == 1
     assert u"Scaling failed" in result.output
-    assert u"ERROR: Service was unable to Lorem Ipsum" in result.output
+    assert re.search("error: [0-9-: \\.+]+Service was unable to Lorem Ipsum", result.output)
 
 
 @patch('ecs_deploy.cli.get_client')
@@ -868,7 +868,7 @@ def test_scale_ignore_warnings(get_client, runner):
     assert not result.exception
     assert result.exit_code == 0
     assert u"Successfully changed desired count to: 2" in result.output
-    assert u"WARNING: Service was unable to Lorem Ipsum" in result.output
+    assert re.search("warning: [0-9-: \\.+]+Service was unable to Lorem Ipsum", result.output)
     assert u"Continuing." in result.output
     assert u"Scaling successful" in result.output
 

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1466,15 +1466,13 @@ def test_ecs_action_get_service():
 
 
 @patch.object(EcsClient, '__init__')
-def test_ecs_action_get_current_task_definition(client, service):
+def test_ecs_action_get_task_definition(client, service):
     client.describe_task_definition.return_value = RESPONSE_TASK_DEFINITION
 
     action = EcsAction(client, u'test-cluster', u'test-service')
-    task_definition = action.get_current_task_definition(service)
+    task_definition = action.get_task_definition(None)
 
-    client.describe_task_definition.assert_called_once_with(
-        task_definition_arn=service.task_definition
-    )
+    client.describe_task_definition.assert_called_once()
 
     assert isinstance(task_definition, EcsTaskDefinition)
     assert task_definition.family == u'test-task'


### PR DESCRIPTION
Hey,

I started to implement a feature, where you can trigger multiple deployments at the same time (see example below). It's now possible to specify multiple cluster+service pairs which will be updated simultaneously. If this is a feature you are willing to merge, I'm happy to further clean up the code and fix/add some tests based on your comments.

Example:
```
# Previously, we had to start to individual deployments and wait for the first one to succeed to start the second.
ecs deploy app-messenger-cluster app-messenger-service --tag ${CI_COMMIT_SHORT_SHA} [...]
ecs deploy app-web-cluster app-web-service --tag ${CI_COMMIT_SHORT_SHA} [...]

# Now it's possible to start them at the same time:
ecs deploy app-messenger-cluster app-messenger-service app-web-cluster app-web-service --tag ${CI_COMMIT_SHORT_SHA} [...]
```
