### PR TITLE
Unpin requests; pin urllib3 to match botocore 1.32.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ dependencies = [
     'botocore>=1.32.6',
     'boto3>=1.29.6',
     'future',
-    'requests<2.30.0',
+    'requests',
+    'urllib3>=1.25.4,<1.27 ; python_version < "3.10"',
+    'urllib3>=1.25.4,<2.1 ; python_version >= "3.10"',
     'dictdiffer>=0.9.0',
 ]
 


### PR DESCRIPTION
It would be good to remove the pin `requests<2.30.0` so that we can install the latest version of requests.

I assume the pin was added because botocore was not compatible with urllib3 2.0+ for a while. Therefore I suggest that
we pin urllib3 instead of requests.

I've copied the urllib3 requirements from [botocore 1.32.6](https://github.com/boto/botocore/blob/1.32.6/setup.py#L28), which is the minimum version that ecs-deploy supports. Another option would be to pin `urllib3<1.27` rather than having different pins for different python versions.

Eventually, we can remove the pin when ecs-deploy drops support for Python 3.10.

I've tested this on Python 3.9, which installs:

```
boto3==1.34.139
botocore==1.34.139
certifi==2024.7.4
charset-normalizer==3.3.2
click==8.1.7
click-log==0.3.2
dictdiffer==0.9.0
ecs-deploy==1.15.0
future==1.0.0
idna==3.7
jmespath==1.0.1
python-dateutil==2.9.0.post0
requests==2.32.3
s3transfer==0.10.2
six==1.16.0
urllib3==1.26.19
```

and Python 3.12, which installs:

```
% pip freeze
boto3==1.34.139
botocore==1.34.139
certifi==2024.7.4
charset-normalizer==3.3.2
click==8.1.7
click-log==0.3.2
dictdiffer==0.9.0
ecs-deploy @ file:///Users/anicol/dev/ecs-deploy
future==1.0.0
idna==3.7
jmespath==1.0.1
python-dateutil==2.9.0.post0
requests==2.32.3
s3transfer==0.10.2
six==1.16.0
urllib3==2.0.7
```

However, I am not sure what the original error was before the `requests<2.30.0` pin was added, so I can't be certain that this change works.