### PR TITLE
Proper handling of image digests

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -464,8 +464,12 @@ class EcsTaskDefinition(object):
                 self._diff.append(diff)
                 container[u'image'] = new_image
             elif tag:
-                image_definition = container[u'image'].rsplit(u':', 1)
-                new_image = u'%s:%s' % (image_definition[0], tag.strip())
+                image = container[u'image']
+                if u"@sha256:" in image:
+                    image = image.rsplit(u'@', 1)[0]
+                if u":" in image:
+                    image = image.rsplit(u':', 1)[0]
+                new_image = u'%s:%s' % (image, tag.strip())
                 diff = EcsTaskDefinitionDiff(
                     container=container[u'name'],
                     field=u'image',


### PR DESCRIPTION
Images can be specified like:
```
nginx
nginx:1.27.0
nginx:1.27.0@sha256:67682bda769fae1ccf5183192b8daf37b64cae99c6c3302650f6f8bf5f0f95df
nginx@sha256:67682bda769fae1ccf5183192b8daf37b64cae99c6c3302650f6f8bf5f0f95df
```

At the moment ecs-deploy can only handle the second case. With this change, all 4 cases work properly.