### PR TITLE
Fix list_tasks pagination for services with >100 tasks

### DIFF
--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -98,10 +98,16 @@ class EcsClient(object):
             )
 
     def list_tasks(self, cluster_name, service_name):
-        return self.boto.list_tasks(
-            cluster=cluster_name,
-            serviceName=service_name
-        )
+        """List all tasks for a service, handling pagination.
+
+        The AWS list_tasks API returns a maximum of 100 task ARNs per call.
+        This method paginates through all results to get the complete list.
+        """
+        task_arns = []
+        paginator = self.boto.get_paginator('list_tasks')
+        for page in paginator.paginate(cluster=cluster_name, serviceName=service_name):
+            task_arns.extend(page.get('taskArns', []))
+        return {'taskArns': task_arns}
 
     def describe_tasks(self, cluster_name, task_arns):
         return self.boto.describe_tasks(cluster=cluster_name, tasks=task_arns)

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1233,8 +1233,19 @@ def test_client_describe_unknown_task_definition(client):
 
 
 def test_client_list_tasks(client):
-    client.list_tasks(u'test-cluster', u'test-service')
-    client.boto.list_tasks.assert_called_once_with(cluster=u'test-cluster', serviceName=u'test-service')
+    # Mock paginator to return task ARNs
+    mock_paginator = Mock()
+    mock_paginator.paginate.return_value = [
+        {'taskArns': ['task-arn-1', 'task-arn-2']},
+        {'taskArns': ['task-arn-3']},
+    ]
+    client.boto.get_paginator.return_value = mock_paginator
+
+    result = client.list_tasks(u'test-cluster', u'test-service')
+
+    client.boto.get_paginator.assert_called_once_with('list_tasks')
+    mock_paginator.paginate.assert_called_once_with(cluster=u'test-cluster', serviceName=u'test-service')
+    assert result == {'taskArns': ['task-arn-1', 'task-arn-2', 'task-arn-3']}
 
 
 def test_client_describe_tasks(client):


### PR DESCRIPTION
## Summary

The AWS `list_tasks` API returns a maximum of 100 task ARNs per call and provides a `nextToken` for pagination. The previous implementation did not handle pagination, causing `is_deployed()` to always return `False` for services with more than 100 tasks (since `running_count` would be capped at 100 but `desired_count` could be higher).

This fix uses boto3's paginator to retrieve all task ARNs, ensuring accurate task counts regardless of service size.

## Changes

- Updated `EcsClient.list_tasks()` to use boto3's paginator instead of a single API call
- Updated the corresponding unit test to verify pagination behavior

## Testing

- All existing `is_deployed` tests pass
- Verified locally that the paginator correctly retrieves all tasks

Fixes #242