### PR TITLE
Add force new deployment option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,13 @@ This will duplicate the current task definition and cause the service to redeplo
 
     $ ecs deploy my-cluster my-service
 
+Force a new deployment
+======================
+To ask ECS to start a new deployment even when the service is already using the requested task definition, pass
+``--force-new-deployment``. This is useful when an image tag points to a new digest and you want ECS to resolve it again.::
+
+    $ ecs deploy my-cluster my-service --force-new-deployment
+
 
 Deploy a new tag
 ================

--- a/ecs_deploy/cli.py
+++ b/ecs_deploy/cli.py
@@ -61,6 +61,7 @@ def get_client(access_key_id, secret_access_key, region, profile, assume_account
 @click.option('--account', help='Target AWS account id to deploy in')
 @click.option('--assume-role', help='AWS Role to assume in target account')
 @click.option('--timeout', required=False, default=300, type=int, help='Amount of seconds to wait for deployment before command fails (default: 300). To disable timeout (fire and forget) set to -1')
+@click.option('--force-new-deployment', is_flag=True, default=False, help='Force ECS to start a new deployment')
 @click.option('--ignore-warnings', is_flag=True, help='Do not fail deployment on warnings (port already in use or insufficient memory/CPU)')
 @click.option('--newrelic-apikey', required=False, help='New Relic API Key for recording the deployment. Can also be defined via environment variable NEW_RELIC_API_KEY')
 @click.option('--newrelic-appid', required=False, help='New Relic App ID for recording the deployment. Can also be defined via environment variable NEW_RELIC_APP_ID')
@@ -85,7 +86,7 @@ def get_client(access_key_id, secret_access_key, region, profile, assume_account
 @click.option('--volume', type=(str, str), multiple=True, required=False, help='Set volume mapping from host to container in the task definition.')
 @click.option('--add-container', type=str, multiple=True, required=False, help='Add a placeholder container in the task definition.')
 @click.option('--remove-container', type=str, multiple=True, required=False, help='Remove a container from the task definition.')
-def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, essential, env, env_file, s3_env_file, secret, secrets_env_file, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, account, assume_role, timeout, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
+def deploy(cluster, service, tag, image, command, health_check, cpu, memory, memoryreservation, task_cpu, task_memory, privileged, essential, env, env_file, s3_env_file, secret, secrets_env_file, ulimit, system_control, port, mount, log, role, execution_role, runtime_platform, task, region, access_key_id, secret_access_key, profile, account, assume_role, timeout, force_new_deployment, newrelic_apikey, newrelic_appid, newrelic_region, newrelic_revision, comment, user, ignore_warnings, diff, deregister, rollback, exclusive_env, exclusive_secrets, exclusive_s3_env_file, sleep_time, exclusive_ulimits, exclusive_system_controls, exclusive_ports, exclusive_mounts, volume, add_container, remove_container, slack_url, docker_label, exclusive_docker_labels, slack_service_match='.*'):
     """
     Redeploy or modify a service.
 
@@ -153,7 +154,8 @@ def deploy(cluster, service, tag, image, command, health_check, cpu, memory, mem
                 deregister=deregister,
                 previous_task_definition=td,
                 ignore_warnings=ignore_warnings,
-                sleep_time=sleep_time
+                sleep_time=sleep_time,
+                force_new_deployment=force_new_deployment
             )
 
         except TaskPlacementError as e:
@@ -560,9 +562,13 @@ def wait_for_finish(action, timeout, title, success_message, failure_message,
 
 def deploy_task_definition(deployment, task_definition, title, success_message,
                            failure_message, timeout, deregister,
-                           previous_task_definition, ignore_warnings, sleep_time):
+                           previous_task_definition, ignore_warnings, sleep_time,
+                           force_new_deployment=False):
     click.secho('Updating service')
-    deployment.deploy(task_definition)
+    deployment.deploy(
+        task_definition,
+        force_new_deployment=force_new_deployment
+    )
 
     message = 'Successfully changed task definition to: %s:%s\n' % (
         task_definition.family,

--- a/ecs_deploy/ecs.py
+++ b/ecs_deploy/ecs.py
@@ -142,19 +142,17 @@ class EcsClient(object):
             taskDefinition=task_definition_arn
         )
 
-    def update_service(self, cluster, service, desired_count, task_definition):
-        if desired_count is None:
-            return self.boto.update_service(
-                cluster=cluster,
-                service=service,
-                taskDefinition=task_definition
-            )
-        return self.boto.update_service(
+    def update_service(self, cluster, service, desired_count, task_definition, force_new_deployment=False):
+        kwargs = dict(
             cluster=cluster,
             service=service,
-            desiredCount=desired_count,
             taskDefinition=task_definition
         )
+        if desired_count is not None:
+            kwargs['desiredCount'] = desired_count
+        if force_new_deployment:
+            kwargs['forceNewDeployment'] = True
+        return self.boto.update_service(**kwargs)
 
     def run_task(self, cluster, task_definition, count, started_by, overrides,
                  launchtype='EC2', subnets=(), security_groups=(),
@@ -1370,13 +1368,16 @@ class EcsAction(object):
     def deregister_task_definition(self, task_definition):
         self._client.deregister_task_definition(task_definition.arn)
 
-    def update_service(self, service, desired_count=None):
-        response = self._client.update_service(
+    def update_service(self, service, desired_count=None, force_new_deployment=False):
+        kwargs = dict(
             cluster=service.cluster,
             service=service.name,
             desired_count=desired_count,
             task_definition=service.task_definition
         )
+        if force_new_deployment:
+            kwargs['force_new_deployment'] = True
+        response = self._client.update_service(**kwargs)
         return EcsService(self._cluster_name, response[u'service'])
 
     def is_deployed(self, service):
@@ -1431,10 +1432,13 @@ class EcsAction(object):
 
 
 class DeployAction(EcsAction):
-    def deploy(self, task_definition):
+    def deploy(self, task_definition, force_new_deployment=False):
         try:
             self._service.set_task_definition(task_definition)
-            return self.update_service(self._service)
+            return self.update_service(
+                self._service,
+                force_new_deployment=force_new_deployment
+            )
         except ClientError as e:
             raise EcsError(str(e))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,15 @@ def test_deploy_without_deregister(get_client, runner):
 
 
 @patch('ecs_deploy.cli.get_client')
+def test_deploy_with_force_new_deployment(get_client, runner):
+    get_client.return_value = EcsTestClient('acces_key', 'secret_key')
+    result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '--force-new-deployment'))
+    assert result.exit_code == 0
+    assert not result.exception
+    assert get_client.return_value.force_new_deployment is True
+
+
+@patch('ecs_deploy.cli.get_client')
 def test_deploy_with_role_arn(get_client, runner):
     get_client.return_value = EcsTestClient('acces_key', 'secret_key')
     result = runner.invoke(cli.deploy, (CLUSTER_NAME, SERVICE_NAME, '-r', 'arn:new:role'))

--- a/tests/test_ecs.py
+++ b/tests/test_ecs.py
@@ -1420,6 +1420,16 @@ def test_client_update_service_without_desired_count(client):
     )
 
 
+def test_client_update_service_with_force_new_deployment(client):
+    client.update_service(u'test-cluster', u'test-service', None, u'task-definition', True)
+    client.boto.update_service.assert_called_once_with(
+        cluster=u'test-cluster',
+        service=u'test-service',
+        taskDefinition=u'task-definition',
+        forceNewDeployment=True
+    )
+
+
 def test_client_run_task(client):
     client.run_task(
         cluster=u'test-cluster',
@@ -1546,6 +1556,23 @@ def test_update_service(client, service):
 
 
 @patch.object(EcsClient, '__init__')
+def test_update_service_with_force_new_deployment(client, service):
+    client.update_service.return_value = RESPONSE_SERVICE
+
+    action = EcsAction(client, CLUSTER_NAME, SERVICE_NAME)
+    new_service = action.update_service(service, force_new_deployment=True)
+
+    assert isinstance(new_service, EcsService)
+    client.update_service.assert_called_once_with(
+        cluster=service.cluster,
+        service=service.name,
+        desired_count=None,
+        task_definition=service.task_definition,
+        force_new_deployment=True
+    )
+
+
+@patch.object(EcsClient, '__init__')
 def test_is_deployed(client, service):
     client.list_tasks.return_value = RESPONSE_LIST_TASKS_1
     client.describe_tasks.return_value = RESPONSE_DESCRIBE_TASKS
@@ -1641,6 +1668,23 @@ def test_deploy_action(client, task_definition_revision_2):
         service=action.service.name,
         desired_count=action.service.desired_count,
         task_definition=task_definition_revision_2.arn
+    )
+
+
+@patch.object(EcsClient, '__init__')
+def test_deploy_action_with_force_new_deployment(client, task_definition_revision_2):
+    action = DeployAction(client, CLUSTER_NAME, SERVICE_NAME)
+    updated_service = action.deploy(task_definition_revision_2, force_new_deployment=True)
+
+    assert action.service.task_definition == task_definition_revision_2.arn
+    assert isinstance(updated_service, EcsService)
+
+    client.update_service.assert_called_once_with(
+        cluster=action.service.cluster,
+        service=action.service.name,
+        desired_count=action.service.desired_count,
+        task_definition=task_definition_revision_2.arn,
+        force_new_deployment=True
     )
 
 
@@ -1792,6 +1836,7 @@ class EcsTestClient(object):
         self.deployment_errors = deployment_errors
         self.client_errors = client_errors
         self.wait_until = datetime.now() + timedelta(seconds=wait)
+        self.force_new_deployment = False
 
     def describe_services(self, cluster_name, service_name):
         if not self.access_key_id or not self.secret_access_key:
@@ -1835,7 +1880,8 @@ class EcsTestClient(object):
     def deregister_task_definition(self, task_definition_arn):
         return deepcopy(RESPONSE_TASK_DEFINITION)
 
-    def update_service(self, cluster, service, desired_count, task_definition):
+    def update_service(self, cluster, service, desired_count, task_definition, force_new_deployment=False):
+        self.force_new_deployment = force_new_deployment
         if self.client_errors:
             error = dict(Error=dict(Code=123, Message="Something went wrong"))
             raise ClientError(error, 'fake_error')


### PR DESCRIPTION
Summary:
- add a `--force-new-deployment` deploy flag
- pass the flag through the deploy action to ECS `UpdateService` as `forceNewDeployment=True`
- document the flag and add focused regression coverage for the client/action/CLI plumbing

Validation:
- `git diff --check HEAD~1..HEAD`
- static search for `force-new-deployment`, `force_new_deployment`, and `forceNewDeployment`
- remote `Build` workflow passed on Python 3.10, 3.11, 3.12, and 3.13
- remote Codacy Static Code Analysis passed
- Tests not run locally

Fixes #240